### PR TITLE
Touch events helper (tap) on an element

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,3 +653,80 @@ serialize(queryParams);
 ```
 
 
+
+# touch
+  A module to attach different touch events to an element.
+
+**Members**
+
+* [touch](#module_touch)
+  * [touch.Touch#_isTap()](#module_touch.Touch#_isTap)
+  * [touch.Touch#_preventDefault(event)](#module_touch.Touch#_preventDefault)
+  * [touch.Touch#_reset()](#module_touch.Touch#_reset)
+  * [touch.Touch#_touchStartHandler(callback)](#module_touch.Touch#_touchStartHandler)
+  * [touch.Touch#tap(ele, callback)](#module_touch.Touch#tap)
+  * [touch.Touch#_touchEndHandler(callback)](#module_touch.Touch#_touchEndHandler)
+
+<a name="module_touch.Touch#_isTap"></a>
+####touch.Touch#_isTap()
+Check if touch has moved position to determine tap.
+
+**Returns**: `Boolean` - True if position is the same.  
+**Access**: protected  
+<a name="module_touch.Touch#_preventDefault"></a>
+####touch.Touch#_preventDefault(event)
+A helper function to prevent any defaults on a given event
+
+**Params**
+
+- event `Object` - An event object passed from the browser such as mouseover or click  
+
+**Access**: protected  
+<a name="module_touch.Touch#_reset"></a>
+####touch.Touch#_reset()
+Reset touch event variables
+
+**Access**: protected  
+<a name="module_touch.Touch#_touchStartHandler"></a>
+####touch.Touch#_touchStartHandler(callback)
+Touch event handler which will callback if tap is detected.
+
+**Params**
+
+- callback `function` - When tap event has occurred  
+
+**Returns**: `function` - Function for touch event handling  
+**Access**: protected  
+<a name="module_touch.Touch#tap"></a>
+####touch.Touch#tap(ele, callback)
+Setup a tap event allowing for both tap or clicking on an element.
+
+**Params**
+
+- ele `Object` - Node element to attach touch events to  
+- callback `function` - When tap event has occurred  
+
+**Example**  
+```js
+var touch = new Touch(),
+	ele = document.createElement('div');
+
+touch.tap(ele, function () {
+	console.log('I have been tapped');
+});
+// When tapping on the div element if will fire the console log
+// When clicking on the div element it will also fire the console log
+```
+
+<a name="module_touch.Touch#_touchEndHandler"></a>
+####touch.Touch#_touchEndHandler(callback)
+Touch event handler which is called on touch end. Will automatically fire call on click for
+desktop browsers.
+
+**Params**
+
+- callback `function` - When a click event has occurred  
+
+**Returns**: `function` - Function for touch event handling  
+**Access**: protected  
+

--- a/docs/readme.hb
+++ b/docs/readme.hb
@@ -162,3 +162,9 @@ define([
   {{>body~}}
   {{>exported~}}
 {{/module}}
+
+{{#module name="touch"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}

--- a/src/touch.js
+++ b/src/touch.js
@@ -1,0 +1,133 @@
+define([
+    'aux/events'
+], function (Events) {
+
+    /**
+     * A module to attach different touch events to an element.
+     * @exports touch
+     *
+     * @requires module:events
+     */
+    function Touch () {
+        this.events = new Events();
+        this.touchStart = false;
+        this.cachedX = 0;
+        this.cachedY = 0;
+        this.currentX = 0;
+        this.currentY = 0;
+    }
+
+    /**
+     * Check if touch has moved position to determine tap.
+     * @memberOf module:touch
+     *
+     * @protected
+     * @return {Boolean} True if position is the same.
+     */
+    Touch.prototype._isTap = function () {
+        return (this.cachedX === this.currentX) &&
+            (this.cachedY === this.currentY) && !this.touchStart;
+    };
+
+    /**
+     * A helper function to prevent any defaults on a given event
+     * @memberOf module:touch
+     *
+     * @protected
+     * @param {Object} event An event object passed from the browser such as mouseover or click
+     */
+    Touch.prototype._preventDefault = function (event) {
+        if (event.preventDefault) {
+            event.preventDefault();
+        }
+    };
+
+    /**
+     * Reset touch event variables
+     * @memberOf module:touch
+     *
+     * @protected
+     */
+    Touch.prototype._reset = function () {
+        this.touchStart = false;
+        this.cachedX = this.cachedY = this.currentX = this.currentY = 0;
+    };
+
+    /**
+     * Touch event handler which will callback if tap is detected.
+     * @memberOf module:touch
+     *
+     * @protected
+     * @param {Function} callback When tap event has occurred
+     * @return {Function} Function for touch event handling
+     */
+    Touch.prototype._touchStartHandler = function (callback) {
+        var $this = this;
+        return function (event) {
+            $this._preventDefault(event);
+
+            var touch = event.targetTouches ? event.targetTouches[0] : event;
+            $this.touchStart = true;
+            $this.cachedX = $this.currentX = touch.pageX;
+            $this.cachedY = $this.currentY = touch.pageY;
+
+            if (event.type === 'touchstart') {
+                setTimeout(function () {
+                    if ($this._isTap()) {
+                        callback(event);
+                        $this._reset();
+                    }
+                }, 200);
+            }
+        };
+    };
+
+    /**
+     * Setup a tap event allowing for both tap or clicking on an element.
+     * @memberOf module:touch
+     *
+     * @public
+     * @param {Object} ele Node element to attach touch events to
+     * @param {Function} callback When tap event has occurred
+     *
+     * @example
+     * ```js
+     * var touch = new Touch(),
+     * 	ele = document.createElement('div');
+     *
+     * touch.tap(ele, function () {
+     * 	console.log('I have been tapped');
+     * });
+     * // When tapping on the div element if will fire the console log
+     * // When clicking on the div element it will also fire the console log
+     * ```
+     */
+    Touch.prototype.tap = function (ele, callback) {
+        this.events.addListeners(ele, 'touchstart', this._touchStartHandler(callback));
+        this.events.addListeners(ele, 'touchend click', this._touchEndHandler(callback));
+    };
+
+    /**
+     * Touch event handler which is called on touch end. Will automatically fire call on click for
+     * desktop browsers.
+     * @memberOf module:touch
+     *
+     * @protected
+     * @param {Function} callback When a click event has occurred
+     * @return {Function} Function for touch event handling
+     */
+    Touch.prototype._touchEndHandler = function (callback) {
+        var $this = this;
+        return function (event) {
+            $this._preventDefault(event);
+
+            if (event.type === 'click') {
+                callback(event);
+            }
+
+            $this._reset();
+        };
+    };
+
+    return Touch;
+});

--- a/tests/touch.spec.js
+++ b/tests/touch.spec.js
@@ -1,0 +1,107 @@
+define([
+    'aux/touch'
+], function (Touch) {
+    describe('Touch utils', function () {
+
+        var touch,
+            mockEvent = {
+                preventDefault: function () {},
+                type: 'touchstart'
+            };
+
+        beforeEach(function () {
+            touch = new Touch();
+            callback = jasmine.createSpy('callback');
+            spyOn(touch, '_preventDefault').and.callThrough();
+            spyOn(touch, '_reset').and.callThrough();
+        });
+
+        it('should be able to detect isTap', function () {
+            expect(touch._isTap()).toBeTruthy();
+        });
+
+        it('should preventDefault', function () {
+            spyOn(mockEvent, 'preventDefault');
+
+            touch._preventDefault(mockEvent);
+
+            expect(mockEvent.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should reset', function () {
+            touch.touchStart = 1;
+            touch.cachedX = 2;
+            touch.cachedY = 3;
+            touch.currentX = 4;
+            touch.currentY = 5;
+
+            touch._reset();
+
+            expect(touch.touchStart).toEqual(false);
+            expect(touch.cachedX).toEqual(0);
+            expect(touch.cachedY).toEqual(0);
+            expect(touch.currentX).toEqual(0);
+            expect(touch.currentY).toEqual(0);
+        });
+
+        describe('touch start handler', function () {
+            var handler;
+
+            beforeEach(function () {
+                handler = touch._touchStartHandler(callback);
+            });
+
+            it('should return a function', function () {
+                expect(typeof handler).toBe('function');
+            });
+
+            it('should call prevent default', function () {
+                handler(mockEvent);
+
+                expect(touch._preventDefault).toHaveBeenCalledWith(mockEvent);
+            });
+        });
+
+        it('should add listeners for tap', function () {
+            var node = document.createElement('div');
+
+            spyOn(touch.events, 'addListeners');
+
+            touch.tap(node, callback);
+
+            expect(touch.events.addListeners.calls.count()).toEqual(2);
+        });
+
+        describe('touch end handler', function () {
+            var handler;
+
+            beforeEach(function () {
+                handler = touch._touchEndHandler(callback);
+            });
+
+            it('should return a function', function () {
+                expect(typeof handler).toBe('function');
+            });
+
+            it('should call prevent default', function () {
+                handler(mockEvent);
+
+                expect(touch._preventDefault).toHaveBeenCalledWith(mockEvent);
+            });
+
+            it('should callback if event type click', function () {
+                mockEvent.type = 'click';
+
+                handler(mockEvent);
+
+                expect(callback).toHaveBeenCalledWith(mockEvent);
+            });
+
+            it('should reset', function () {
+                handler(mockEvent);
+
+                expect(touch._reset).toHaveBeenCalled();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add's a helper to Auxilium.js to allow for attach an event tap whilst dealing with click (allowing for both environments).