### PR TITLE
Ensure style tag with a specific id is only generated once

### DIFF
--- a/src/style-tag.js
+++ b/src/style-tag.js
@@ -9,8 +9,11 @@ define([
             /**
              * Attaches a css to a specific document
              *
-             * @param {String} css The css text in which to attach to the Style tag
-             * @param {Object} doc The specific document to attach the Style tag (Optional)
+             * @param {Object} params The paramaters for the style tag
+             * @property {String} params.css The css text in which to attach to the Style tag
+             * @property {Object} params.doc The specific document to attach the Style tag (Optional)
+             * @property {String} params.id A specific unique identifier of the style tag
+             *
              *
              * @return {Object} The style tag with the css attached (and attached to the document)
              *
@@ -21,11 +24,11 @@ define([
              * // Returns a style tag with it attached to the document body
              * ```
              */
-            attach: function (css, doc) {
+            attach: function (params) {
                 var node;
-                doc = doc || document;
+                doc = params.document || document;
 
-                node = this.generate(css, doc);
+                node = this.generate(params);
                 doc.body.appendChild(node);
 
                 return node;
@@ -50,10 +53,12 @@ define([
                 return node.innerHTML;
             },
             /**
-             * Creates a Style tag and attaches css
+             * Creates a Style tag and attaches the css, checking if the script tag with the specific ID exists already.
              *
-             * @param {String} css The css text in which to attach to the Style tag
-             * @param {Object} doc The specific document to use in order to create the Style tag
+             * @param {Object} params The paramaters for the style tag
+             * @property {String} params.css The css text in which to attach to the Style tag
+             * @property {Object} params.doc The specific document to attach the Style tag (Optional)
+             * @property {String} params.id A specific unique identifier of the style tag
              *
              * @return {Object} The style tag with the css attached
              *
@@ -64,16 +69,22 @@ define([
              * // Returns a style tag with css contents attached
              * ```
              */
-            generate: function (css, doc) {
-                var style = doc.createElement('style');
+            generate: function (params) {
+                var css = params.css,
+                    doc = params.document || document,
+                    style = (params.id) ? doc.getElementById(params.id) : null;
 
-                style.type = 'text/css';
+                if (!style) {
+                    style = doc.createElement('style');
+                    style.type = 'text/css';
+                    style.id = params.id;
 
-                if (style.styleSheet) {
-                    style.styleSheet.cssText = css;
-                } else {
-                    var textNode = doc.createTextNode(css);
-                    style.appendChild(textNode);
+                    if (style.styleSheet) {
+                        style.styleSheet.cssText = css;
+                    } else {
+                        var textNode = doc.createTextNode(css);
+                        style.appendChild(textNode);
+                    }
                 }
 
                 return style;

--- a/tests/style-tag.spec.js
+++ b/tests/style-tag.spec.js
@@ -4,25 +4,62 @@ define([
     describe('Attach style', function () {
         var css = '.test-element{z-index:999;top:0;left:0;}';
 
-        it('should generate a style tag', function () {
-            var tag = styleTag.generate(css, document);
+        describe('generation of a tag', function () {
+            var tag;
 
-            expect(tag.tagName).toBeIgnoreCase('style');
+            beforeEach(function () {
+                tag = styleTag.generate({
+                    css: css,
+                    document: document,
+                    id: 'jeff-goldblum'
+                });
+
+                document.body.appendChild(tag);
+            });
+
+            afterEach(function () {
+                document.body.removeChild(tag);
+            });
+
+            it('should generate a style tag', function () {
+                expect(tag.tagName).toBeIgnoreCase('style');
+            });
+
+            it('should return an existing style tag with an id', function () {
+                spyOn(document.body, 'appendChild');
+
+                var params = {
+                        css: '.some-other-css { body { display: none; }}',
+                        document: document,
+                        id: 'jeff-goldblum'
+                    },
+                    style = styleTag.generate(params);
+
+                expect(style).toBe(tag);
+                expect(styleTag.contents(style)).toBe(styleTag.contents(tag));
+            });
         });
 
         it('should attach a style tag', function () {
             spyOn(styleTag, 'generate').and.callThrough();
             spyOn(document.body, 'appendChild');
 
-            var style = styleTag.attach(css, document);
+            var params = {
+                    css: css,
+                    document: document
+                },
+                style = styleTag.attach(params);
 
-            expect(styleTag.generate).toHaveBeenCalledWith(css, document);
+            expect(styleTag.generate).toHaveBeenCalledWith(params);
             expect(document.body.appendChild).toHaveBeenCalledWith(style);
         });
 
         it('should retrieve css contents', function () {
             // IE9 returns the css with carriage returns and spaces
-            var style = styleTag.attach(css, document),
+            var style = styleTag.generate({
+                    css: css,
+                    document: document
+                }),
                 contents = styleTag.contents(style);
 
             expect(contents).toContain('.test-element');


### PR DESCRIPTION
Specifying an ID on a style tag ensures that the tag is only generated once and returns the original if it already exists on the document.