### PR TITLE
Create a console logger helper checking available

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ var div = document.createElement('div'),
 **Returns**: `object` - A fresh instance of the object originally passed  
 
 
+# console-logger
+  Using the browsers console logging options, allowing to use console.error if accessible otherwise fallsback to
+console.log (again if accessible).
+
+**Params**
+
+- message `string` - Message to log out  
+- type `string` - What logging system to use error, log (defaults to log).  
+
+
+
 # create-element
   Creates an element and returns the element
 
@@ -720,7 +731,7 @@ Attaches a css to a specific document
 **Properties**
 
   - params.css `String` - The css text in which to attach to the Style tag  
-  - params.doc `Object` - The specific document to attach the Style tag (Optional)  
+  - params.document `Object` - The specific document to attach the Style tag (Optional)  
   - params.id `String` - A specific unique identifier of the style tag  
 
 **Scope**: inner function of [style-tag](#module_style-tag)  
@@ -769,7 +780,7 @@ Creates a Style tag and attaches the css, checking if the script tag with the sp
 **Properties**
 
   - params.css `String` - The css text in which to attach to the Style tag  
-  - params.doc `Object` - The specific document to attach the Style tag (Optional)  
+  - params.document `Object` - The specific document to attach the Style tag (Optional)  
   - params.id `String` - A specific unique identifier of the style tag  
 
 **Scope**: inner function of [style-tag](#module_style-tag)  

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ console.log (again if accessible).
 
 **Params**
 
-- message `string` - Message to log out  
-- type `string` - What logging system to use error, log (defaults to log).  
+- message `*` - Message to log out  
+- type `String` - What logging system to use error, log (defaults to log).  
 
 
 

--- a/docs/readme.hb
+++ b/docs/readme.hb
@@ -73,6 +73,12 @@ define([
   {{>exported~}}
 {{/module}}
 
+{{#module name="console-logger"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}
+
 {{#module name="create-element"~}}
   # {{>name}}
   {{>body~}}

--- a/src/console-logger.js
+++ b/src/console-logger.js
@@ -1,23 +1,24 @@
 define([
-    'aux/has-property'
-], function (hasProperty) {
+    'aux/is-defined'
+], function (isDefined) {
     /**
      * Using the browsers console logging options, allowing to use console.error if accessible otherwise fallsback to
      * console.log (again if accessible).
      *
      * @exports console-logger
      *
-     * @requires module:has-property
+     * @requires module:is-defined
      *
      * @param {*} message Message to log out
      * @param {String} type What logging system to use error, log (defaults to log).
      */
     function logger (message, type) {
+        var console = window.console;
         type = type || 'log';
 
-        if (hasProperty(window, 'console.' + type)) {
+        if (isDefined(console[type], 'function')) {
             console[type](message);
-        } else if (hasProperty(window, 'console.log')) {
+        } else if (isDefined(console.log, 'function')) {
             console.log(message);
         }
     }

--- a/src/console-logger.js
+++ b/src/console-logger.js
@@ -7,8 +7,10 @@ define([
      *
      * @exports console-logger
      *
-     * @param {string} message Message to log out
-     * @param {string} type What logging system to use error, log (defaults to log).
+     * @requires module:has-property
+     *
+     * @param {*} message Message to log out
+     * @param {String} type What logging system to use error, log (defaults to log).
      */
     function logger (message, type) {
         type = type || 'log';

--- a/src/console-logger.js
+++ b/src/console-logger.js
@@ -1,0 +1,24 @@
+define([
+    'aux/has-property'
+], function (hasProperty) {
+    /**
+     * Using the browsers console logging options, allowing to use console.error if accessible otherwise fallsback to
+     * console.log (again if accessible).
+     *
+     * @exports console-logger
+     *
+     * @param {string} message Message to log out
+     * @param {string} type What logging system to use error, log (defaults to log).
+     */
+    function logger (message, type) {
+        type = type || 'log';
+
+        if (hasProperty(window, 'console.' + type)) {
+            console[type](message);
+        } else if (hasProperty(window, 'console.log')) {
+            console.log(message);
+        }
+    }
+
+    return logger;
+});

--- a/tests/console-logger.spec.js
+++ b/tests/console-logger.spec.js
@@ -1,0 +1,32 @@
+define([
+    'aux/console-logger'
+], function (logger) {
+    describe('Using a browser\'s logging system', function () {
+        beforeEach(function () {
+            window.console = window.console || {};
+            window.console.log = window.console.log || function () {};
+            window.console.error = window.console.error || function () {};
+        });
+
+        it('should default to use console log when type not passed', function () {
+            spyOn(window.console, 'log');
+            logger('I work');
+
+            expect(window.console.log).toHaveBeenCalledWith('I work');
+        });
+
+        it('should use console error when specified', function () {
+            spyOn(window.console, 'error');
+            logger('AAAH ERROR to CONSOLE!', 'error');
+
+            expect(window.console.error).toHaveBeenCalledWith('AAAH ERROR to CONSOLE!');
+        });
+
+        it('should fallback to use console log when passed type isn\'t accessible', function () {
+            spyOn(window.console, 'log');
+            logger('uhoh fallback to log!', 'someRandomConsoleMethod');
+
+            expect(window.console.log).toHaveBeenCalledWith('uhoh fallback to log!');
+        });
+    });
+});


### PR DESCRIPTION
Console logger helper within Auxilium to ensure that the browser being served within allows for console logging prior to executing.

Allows for the use of ``console.log`` & ``console.error`` for example