### PR TITLE
Create a innerHTML & validateHTML helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,30 @@ hyphenToCamel('barney-stinson');
 
 
 
+# inner-html
+  Attaches a string representation of a DOM to an element ensuring that a script tag is created rather than
+simply using innerHTML to ensure it will be executable when attached to the DOM.
+NOTE: When invalid HTML is passed to the function it will throw an error
+
+**Params**
+
+- node `Object` - The HTML DOMNode in which to attach the html to  
+- html `String` - The string representation of the DOM  
+
+**Returns**: `Object` - node The HTML DOMNode with the string representation attached (inside).  
+**Example**  
+```js
+var div = document.createElement('div');
+div = innerHTML(div, '<span></span>');
+// Returns '<div><span></span></div>'
+
+div = innerHTML(div, '<script>console.log("log something");</script>');
+// Returns '<div><script>console.log("log something");</script></div>'
+// Executing the script tag once attached to the document body
+```
+
+
+
 # is-defined
   **Params**
 
@@ -798,7 +822,6 @@ var css = 'body { margin: 0 auto; };',
 
 
 
-
 # touch
   A module to attach different touch events to an element.
 
@@ -874,4 +897,26 @@ desktop browsers.
 
 **Returns**: `function` - Function for touch event handling  
 **Access**: protected  
+
+
+# validate-html
+  Checks that HTML as string is valid HTML (all tags are closing etc.)
+
+**Params**
+
+- html `String` - The html to validate  
+
+**Returns**: `Boolean` - Whether or not the html is valid  
+**Example**  
+```js
+validateHtml('<div></div>');
+// Returns true
+
+validateHtml('<div>');
+// Returns false
+
+validateHtml('<div></div');
+// Returns false
+```
+
 

--- a/docs/readme.hb
+++ b/docs/readme.hb
@@ -139,6 +139,12 @@ define([
   {{>exported~}}
 {{/module}}
 
+{{#module name="inner-html"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}
+
 {{#module name="is-defined"~}}
   # {{>name}}
   {{>body~}}
@@ -187,8 +193,13 @@ define([
   {{>exported~}}
 {{/module}}
 
-
 {{#module name="touch"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}
+
+{{#module name="validate-html"~}}
   # {{>name}}
   {{>body~}}
   {{>exported~}}

--- a/src/inner-html.js
+++ b/src/inner-html.js
@@ -24,12 +24,13 @@ define([
             newNode;
 
         // Loop through all of the attributes set to the existing node to ensure all are attached to the new node
-        for (var attr = 0; attr < attributes.length - 1; attr++) {
+        for (var attr = 0; attr < attributes.length; attr++) {
+            var attibuteName = attributes[attr].nodeName;
             // Don't allow the use of an attribute with class force classname
-            if (attributes === 'class') {
-                manifest.attr['className'] = attributes[attr];
+            if (attibuteName === 'class') {
+                manifest.cssNames = attributes[attr].nodeValue;
             } else {
-                manifest.attr[attr] = attributes[attr];
+                manifest.attr[attibuteName] = attributes[attr].nodeValue;
             }
         }
 
@@ -72,7 +73,7 @@ define([
      */
     function innerHTML (node, html) {
         if (!validateHtml(html)) {
-            throw Error('HTML is not valid', html);
+            throw Error('HTML is not valid: ' + html);
         }
 
         node.innerHTML = html;

--- a/src/inner-html.js
+++ b/src/inner-html.js
@@ -1,0 +1,88 @@
+define([
+    'aux/get-element-by-tag',
+    'aux/create-element',
+    'aux/validate-html'
+], function (getElementByTag, createElement, validateHtml) {
+
+    /**
+     * @memberOf module:inner-html
+     * @private
+     *
+     * @description
+     * Replaces a node with a newely generated DOMNode (ideal for <script> tags when originally created by innerHTML).
+     *
+     * @param {Object} node The HTML DOMNode in which to replace with a created element
+     *
+     * @returns {Object} newNode The new generated DOMNode of the original node passed to the function
+     */
+    function recreateNode (node) {
+        var manifest = {
+                attr: {}
+            },
+            attributes = node.attributes,
+            nodeType = node.tagName.toLowerCase(),
+            newNode;
+
+        // Loop through all of the attributes set to the existing node to ensure all are attached to the new node
+        for (var attr = 0; attr < attributes.length - 1; attr++) {
+            // Don't allow the use of an attribute with class force classname
+            if (attributes === 'class') {
+                manifest.attr['className'] = attributes[attr];
+            } else {
+                manifest.attr[attr] = attributes[attr];
+            }
+        }
+
+        // Create the new node
+        newNode = createElement(nodeType, manifest);
+        // Add any inner html back to the element
+        newNode.innerHTML = node.innerHTML;
+
+        node.parentNode.replaceChild(newNode, node);
+
+        return newNode;
+    }
+
+    /**
+     * @exports inner-html
+     * @description
+     * Attaches a string representation of a DOM to an element ensuring that a script tag is created rather than
+     * simply using innerHTML to ensure it will be executable when attached to the DOM.
+     * NOTE: When invalid HTML is passed to the function it will throw an error
+     *
+     * @requires module:validate-html
+     * @requires module:create-element
+     * @requires module:get-element-by-tag
+     *
+     * @param {Object} node The HTML DOMNode in which to attach the html to
+     * @param {String} html The string representation of the DOM
+     *
+     * @returns {Object} node The HTML DOMNode with the string representation attached (inside).
+     *
+     * @example
+     * ```js
+     * var div = document.createElement('div');
+     * div = innerHTML(div, '<span></span>');
+     * // Returns '<div><span></span></div>'
+     *
+     * div = innerHTML(div, '<script>console.log("log something");</script>');
+     * // Returns '<div><script>console.log("log something");</script></div>'
+     * // Executing the script tag once attached to the document body
+     * ```
+     */
+    function innerHTML (node, html) {
+        if (!validateHtml(html)) {
+            throw Error('HTML is not valid', html);
+        }
+
+        node.innerHTML = html;
+
+        // Replace all script tags with created elements
+        getElementByTag(node, 'script', recreateNode);
+
+        return node;
+    }
+
+    return innerHTML;
+
+});

--- a/src/validate-html.js
+++ b/src/validate-html.js
@@ -1,0 +1,31 @@
+define([
+], function () {
+    /**
+     * @exports validate-html
+     * @description
+     * Checks that HTML as string is valid HTML (all tags are closing etc.)
+     *
+     * @param {String} html The html to validate
+     *
+     * @return {Boolean} Whether or not the html is valid
+     *
+     * @example
+     * ```js
+     * validateHtml('<div></div>');
+     * // Returns true
+     *
+     * validateHtml('<div>');
+     * // Returns false
+     *
+     * validateHtml('<div></div');
+     * // Returns false
+     * ```
+     */
+    function validateHtml (html) {
+        var doc = document.createElement('div');
+        doc.innerHTML = html;
+        return (doc.innerHTML === html);
+    }
+
+    return validateHtml;
+});

--- a/tests/inner-html.spec.js
+++ b/tests/inner-html.spec.js
@@ -1,6 +1,7 @@
 define([
-    'aux/inner-html'
-], function (innerHTML) {
+    'aux/inner-html',
+    'aux/get-elements-by-class'
+], function (innerHTML, getElementByClass) {
     describe('Parse HTML', function () {
         var node;
 
@@ -38,6 +39,20 @@ define([
             document.body.appendChild(node);
             expect(window.console.log).toHaveBeenCalledWith('something');
             expect(window.console.log).toHaveBeenCalledWith('another');
+        });
+
+        it('should attach class to the new node', function () {
+            // Ensure that console log is not fired
+            spyOn(console, 'log');
+            var nodeContents = '<div>something</div><script class="some-class" type="text/javascript">' +
+                    'console.log("something");</script><div><script>console.log("another");</script></div>';
+
+            node = innerHTML(node, nodeContents);
+
+            classNodes = getElementByClass(node, 'some-class');
+
+            document.body.appendChild(node);
+            expect(classNodes.length).toBe(1);
         });
     });
 });

--- a/tests/inner-html.spec.js
+++ b/tests/inner-html.spec.js
@@ -1,0 +1,43 @@
+define([
+    'aux/inner-html'
+], function (innerHTML) {
+    describe('Parse HTML', function () {
+        var node;
+
+        beforeEach(function () {
+            node = document.createElement('div');
+        });
+
+        afterEach(function () {
+            document.body.removeChild(node);
+        });
+
+        it('should execute the contents of a script tag', function () {
+            spyOn(console, 'log');
+
+            var nodeContents = '<div>something</div><script>console.log("something");</script>';
+
+            node = innerHTML(node, nodeContents);
+
+            expect(window.console.log).not.toHaveBeenCalled();
+
+            document.body.appendChild(node);
+            expect(window.console.log).toHaveBeenCalledWith('something');
+        });
+
+        it('should run the contents of two individual script tags', function () {
+            spyOn(console, 'log');
+
+            var nodeContents = '<div>something</div><script>console.log("something");</script>' +
+                '<div><script>console.log("another");</script></div>';
+
+            node = innerHTML(node, nodeContents);
+
+            expect(window.console.log).not.toHaveBeenCalled();
+
+            document.body.appendChild(node);
+            expect(window.console.log).toHaveBeenCalledWith('something');
+            expect(window.console.log).toHaveBeenCalledWith('another');
+        });
+    });
+});

--- a/tests/validate-html.spec.js
+++ b/tests/validate-html.spec.js
@@ -1,0 +1,31 @@
+define([
+    'aux/validate-html'
+], function (validateHTML) {
+    describe('Validate HTML string', function () {
+        it('should return that html is valid', function () {
+            var html = '<div></div>';
+
+            expect(validateHTML(html)).toBeTruthy();
+        });
+
+        it('should return that html is not valid', function () {
+            var html = '<div></div';
+
+            expect(validateHTML(html)).toBeFalsy();
+        });
+
+        it('should return that html with nested elements is valid', function () {
+            var html = '<div id="someId"><span>some span</span><style>div { display: block; }</style>' +
+                '<div><div>Very nested</div></div></div><div></div><script></script>';
+
+            expect(validateHTML(html)).toBeTruthy();
+        });
+
+        it('should return that html with nested elements is not valid', function () {
+            var html = '<div id="someId"><span>some span</span><style>div { display: block; }</style>' +
+                '<div><div>Very nested</div</div></div><div></div><script></script>';
+
+            expect(validateHTML(html)).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
- ``inner-html`` attaches a string representation of a DOM to an element whilst ensuring that a script tag is created rather than simply using innerHTML
- ``validate-html`` checks that a string representation of ``HTML`` is valid