### PR TITLE
Create elements with contents and children

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ console.log (again if accessible).
   - params.cssNames `string` | `array` - Contains css class name or names in which to attach to an element.  
   - params.events `object` - Contains event handlers to be attached to an element  
   - params.innerHTML `string` - A string representation of DOM elements to attach as children to the ele  
-  - params.innerElements `array` - An array containing elements to create as children  
+  - params.nodes `array` - An array containing elements to create as children  
   - params.children `array` - An array of HTMLNodes to append as children to the element  
 
 **Returns**:  - ele The HTML element created with css and attributes added to passed from params  
@@ -240,11 +240,11 @@ var childEle = createElement('div'),
 	   },
 	   cssNames: ['legen', 'wait-for-it', 'dary'],
 	   innerHTML: '<div class="simpsons"><span class="bart"></span></div>',
-	   innerElements: [
+	   nodes: [
 	   	{
 	   		tag: 'div',
 	   		cssNames: 'family-guy',
-	   		innerElements: {
+	   		nodes: {
 	   			tag: 'span',
 				cssNames: 'peter'
 			}

--- a/README.md
+++ b/README.md
@@ -210,34 +210,58 @@ console.log (again if accessible).
 
 - tag `string` - The HTML tag type in which to create  
 - params `object` - Contains paramaters to be used for the creation of the element  
-  - attr `object` - Contains the attributes and values for the HTMLNode  
-  - css `object` - Contains the css styling to be added to the element  
-  - cssNames `string` | `array` - Contains css class name or names in which to attach to an element.  
-  - events `object` - Contains event handlers to be attached to an element  
+
+**Properties**
+
+  - params.attr `object` - Contains the attributes and values for the HTMLNode  
+  - params.css `object` - Contains the css styling to be added to the element  
+  - params.cssNames `string` | `array` - Contains css class name or names in which to attach to an element.  
+  - params.events `object` - Contains event handlers to be attached to an element  
+  - params.innerHTML `string` - A string representation of DOM elements to attach as children to the ele  
+  - params.innerElements `array` - An array containing elements to create as children  
+  - params.children `array` - An array of HTMLNodes to append as children to the element  
 
 **Returns**:  - ele The HTML element created with css and attributes added to passed from params  
 **Example**  
 ```js
-var params = {
+var childEle = createElement('div'),
+	params = {
 		attr: {
-			src: 'http://rockabox.com/example.gif'
-		},
+			'id': 'some-div'
+		}
 		events: {
-			load: function () {
-				console.log('Fire me when the image is loaded');
+			click: function () {
+				console.log('Fire me when I am clicked');
+		  }
+	   },
+	   css: {
+		  border: '1px solid black',
+		  backgroundColor: 'red'
+	   },
+	   cssNames: ['legen', 'wait-for-it', 'dary'],
+	   innerHTML: '<div class="simpsons"><span class="bart"></span></div>',
+	   innerElements: [
+	   	{
+	   		tag: 'div',
+	   		cssNames: 'family-guy',
+	   		innerElements: {
+	   			tag: 'span',
+				cssNames: 'peter'
 			}
-		},
-		css: {
-			border: '1px solid black',
-			backgroundColor: 'red'
-		},
-		cssNames: ['legen', 'wait-for-it', 'dary']
-};
-var imageEle = createElement('img', params);
-// Returns
-// <img src="http://rockabox.com/example.gif" style="border: 1px solid black; background-color: red;"
-//   class="legen wait-for-it dary" />;
-// When the image source has loaded a function will be ran console logging out.
+		}
+	   ],
+	   children: [
+	   	childEle
+	   ]
+    },
+    ele = createElement('div', params);
+// Ele becomes
+// <div style="border: 1px solid black; background-color: red;" class="legen wait-for-it dary">
+//   <div class="simpsons"><span class="bart"></span></div>
+//   <div class="family-guy"><span class="peter"></span></div>
+//   <div></div>
+// </div>
+// Clicking on the main div will console log
 ```
 
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -22,7 +22,7 @@ define([
      * @property {string|array} params.cssNames Contains css class name or names in which to attach to an element.
      * @property {object} params.events Contains event handlers to be attached to an element
      * @property {string} params.innerHTML A string representation of DOM elements to attach as children to the ele
-     * @property {array} params.innerElements An array containing elements to create as children
+     * @property {array} params.nodes An array containing elements to create as children
      * @property {array} params.children An array of HTMLNodes to append as children to the element
      *
      * @returns ele The HTML element created with css and attributes added to passed from params
@@ -45,11 +45,11 @@ define([
      * 	   },
      * 	   cssNames: ['legen', 'wait-for-it', 'dary'],
      * 	   innerHTML: '<div class="simpsons"><span class="bart"></span></div>',
-     * 	   innerElements: [
+     * 	   nodes: [
      * 	   	{
      * 	   		tag: 'div',
      * 	   		cssNames: 'family-guy',
-     * 	   		innerElements: {
+     * 	   		nodes: {
      * 	   			tag: 'span',
      * 				cssNames: 'peter'
      * 			}
@@ -87,8 +87,8 @@ define([
         }
 
         // Using an object create new elements with this same module
-        if (params.innerElements) {
-            inner = params.innerElements;
+        if (params.nodes) {
+            inner = params.nodes;
 
             for (var i = 0; i < inner.length; i++) {
                 ele.appendChild(createElement(inner[i].tag, inner[i]));

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -2,8 +2,9 @@ define([
     './attach-attr',
     './attach-class',
     './attach-css',
-    './attach-events'
-], function (attachAttr, attachClass, attachCss, attachEvents) {
+    './attach-events',
+    './inner-html'
+], function (attachAttr, attachClass, attachCss, attachEvents, innerHTML) {
     /**
      * Creates an element and returns the element
      * @exports create-element
@@ -12,47 +13,65 @@ define([
      * @requires module:attach-class
      * @requires module:attach-css
      * @requires module:attach-events
+     * @requires module:inner-html
      *
      * @param {string} tag The HTML tag type in which to create
      * @param {object} params Contains paramaters to be used for the creation of the element
-     * @param {object} params.attr Contains the attributes and values for the HTMLNode
-     * @param {object} params.css Contains the css styling to be added to the element
-     * @param {string|array} params.cssNames Contains css class name or names in which to attach to an element.
-     * @param {object} params.events Contains event handlers to be attached to an element
+     * @property {object} params.attr Contains the attributes and values for the HTMLNode
+     * @property {object} params.css Contains the css styling to be added to the element
+     * @property {string|array} params.cssNames Contains css class name or names in which to attach to an element.
+     * @property {object} params.events Contains event handlers to be attached to an element
+     * @property {string} params.innerHTML A string representation of DOM elements to attach as children to the ele
+     * @property {array} params.innerElements An array containing elements to create as children
+     * @property {array} params.children An array of HTMLNodes to append as children to the element
      *
      * @returns ele The HTML element created with css and attributes added to passed from params
      *
-     * @requires attachEvents
-     * @requires attachAttr
-     * @requires attachCss
-     * @requires attachClass
-     *
      * @example
      * ```js
-     * var params = {
+     * var childEle = createElement('div'),
+     * 	params = {
      * 		attr: {
-     * 			src: 'http://rockabox.com/example.gif'
-     * 		},
+     * 			'id': 'some-div'
+     * 		}
      * 		events: {
-     * 			load: function () {
-     * 				console.log('Fire me when the image is loaded');
+     * 			click: function () {
+     * 				console.log('Fire me when I am clicked');
+     * 		  }
+     * 	   },
+     * 	   css: {
+     * 		  border: '1px solid black',
+     * 		  backgroundColor: 'red'
+     * 	   },
+     * 	   cssNames: ['legen', 'wait-for-it', 'dary'],
+     * 	   innerHTML: '<div class="simpsons"><span class="bart"></span></div>',
+     * 	   innerElements: [
+     * 	   	{
+     * 	   		tag: 'div',
+     * 	   		cssNames: 'family-guy',
+     * 	   		innerElements: {
+     * 	   			tag: 'span',
+     * 				cssNames: 'peter'
      * 			}
-     * 		},
-     * 		css: {
-     * 			border: '1px solid black',
-     * 			backgroundColor: 'red'
-     * 		},
-     * 		cssNames: ['legen', 'wait-for-it', 'dary']
-     * };
-     * var imageEle = createElement('img', params);
-     * // Returns
-     * // <img src="http://rockabox.com/example.gif" style="border: 1px solid black; background-color: red;"
-     * //   class="legen wait-for-it dary" />;
-     * // When the image source has loaded a function will be ran console logging out.
+     * 		}
+     * 	   ],
+     * 	   children: [
+     * 	   	childEle
+     * 	   ]
+     *     },
+     *     ele = createElement('div', params);
+     * // Ele becomes
+     * // <div style="border: 1px solid black; background-color: red;" class="legen wait-for-it dary">
+     * //   <div class="simpsons"><span class="bart"></span></div>
+     * //   <div class="family-guy"><span class="peter"></span></div>
+     * //   <div></div>
+     * // </div>
+     * // Clicking on the main div will console log
      * ```
      */
     function createElement (tag, params) {
-        var ele = document.createElement(tag);
+        var ele = document.createElement(tag),
+            inner;
 
         if (typeof params === 'undefined') {
             return ele;
@@ -62,6 +81,26 @@ define([
         attachAttr(ele, params.attr);
         attachCss(ele, params.css);
         attachClass(ele, params.cssNames);
+
+        if (params.innerHTML) {
+            innerHTML(ele, params.innerHTML);
+        }
+
+        // Using an object create new elements with this same module
+        if (params.innerElements) {
+            inner = params.innerElements;
+
+            for (var i = 0; i < inner.length; i++) {
+                ele.appendChild(createElement(inner[i].tag, inner[i]));
+            }
+        }
+
+        // Will add DOM elements which have already been created as children
+        if (params.children) {
+            for (var y = 0; y < params.children.length; y++) {
+                ele.appendChild(params.children[y]);
+            }
+        }
 
         return ele;
     }

--- a/tests/create-element.spec.js
+++ b/tests/create-element.spec.js
@@ -1,6 +1,8 @@
 define([
-    'aux/create-element'
-], function (createElement) {
+    'aux/create-element',
+    'aux/get-elements-by-class',
+    'aux/has-class'
+], function (createElement, getElementsByClass, hasClass) {
     describe('Creating a DOM element', function () {
 
         it('should create an element with no styling or attributes', function () {
@@ -44,6 +46,64 @@ define([
             ele.onclick();
 
             expect(counter).toBe(1);
+        });
+
+        describe('Creating elements with child elements', function () {
+            var params,
+                ele;
+
+            beforeEach(function () {
+                params = {
+                    innerElements: [
+                        {
+                            tag: 'div',
+                            cssNames: 'child-one',
+                            innerElements: [
+                                {
+                                    tag: 'span',
+                                    cssNames: 'child-two'
+                                }
+                            ]
+                        }
+                    ]
+                };
+
+                ele = createElement('div', params);
+            });
+
+            it('should create child elements', function () {
+                expect(getElementsByClass(ele, 'child-one').length).toBe(1);
+            });
+
+            it('should recurssively create elements (a childs children)', function () {
+                var eleTwo = getElementsByClass(ele, 'child-two');
+
+                expect(eleTwo.length).toBe(1);
+                expect(hasClass(eleTwo[0].parentNode, 'child-one')).toBeTruthy();
+            });
+        });
+
+        it('should add text as inner HTML', function () {
+            var params = {
+                    innerHTML: '<div class="something"><span class="something"></span></div>'
+                },
+                ele = createElement('div', params);
+
+            expect(getElementsByClass(ele, 'something').length).toBe(2);
+        });
+
+        it('should add pre-created elements as children when creating the element', function () {
+            var childEle = createElement('div', {
+                    cssNames: 'jazz'
+                }),
+                params = {
+                    children: [childEle]
+                },
+                ele = createElement('div', params),
+                getEle = getElementsByClass(ele, 'jazz');
+
+            expect(getEle.length).toBe(1);
+            expect(getEle[0]).toBe(childEle);
         });
     });
 });

--- a/tests/create-element.spec.js
+++ b/tests/create-element.spec.js
@@ -54,11 +54,11 @@ define([
 
             beforeEach(function () {
                 params = {
-                    innerElements: [
+                    nodes: [
                         {
                             tag: 'div',
                             cssNames: 'child-one',
-                            innerElements: [
+                            nodes: [
                                 {
                                     tag: 'span',
                                     cssNames: 'child-two'


### PR DESCRIPTION
Adds on to the current createElement module the possiblity of creating an element with:
- innerHTML (A string representation of contents for an element)
- children (Pre-created HTMLDOMNodes in which to append to the element when created)
- innerElements (Create new HTMLDOMNodes when creating the element and append -- recursively)