### PR TITLE
Fix an issue where an array can be cloned as an object.

### DIFF
--- a/src/clone.js
+++ b/src/clone.js
@@ -1,16 +1,20 @@
 define([
-], function () {
+    'aux/is-defined'
+], function (isDefined) {
     /**
      * Clones an object, returning a new instance of the object passed.
      *
      * @exports clone
+     *
+     * @requires module:is-defined
      *
      * @param  {object} obj The base object which to make a fresh copy of
      *
      * @return {object}     A fresh instance of the object originally passed
      */
     function clone (obj) {
-        if (obj === null || typeof obj !== 'object') {
+        if (obj === null || !isDefined(obj, 'object')) {
+        // if (obj === null || typeof obj !== 'object') {
             return obj;
         }
 

--- a/src/clone.js
+++ b/src/clone.js
@@ -14,7 +14,6 @@ define([
      */
     function clone (obj) {
         if (obj === null || !isDefined(obj, 'object')) {
-        // if (obj === null || typeof obj !== 'object') {
             return obj;
         }
 

--- a/src/is-defined.js
+++ b/src/is-defined.js
@@ -31,7 +31,11 @@ define([
     function isDefined (check, type) {
         // Check that the variable is a specific type
         if (type) {
-            return (typeof check === type);
+            var regex = new RegExp(/\[object (\w+)]/),
+                string = Object.prototype.toString.call(check).toLowerCase(),
+                matches = string.match(regex);
+
+            return matches[1] === type;
         }
 
         return (typeof check !== 'undefined');

--- a/tests/clone.spec.js
+++ b/tests/clone.spec.js
@@ -2,22 +2,37 @@ define([
     'aux/clone'
 ], function (clone) {
     describe('Clone an object util function', function () {
-        it('should be able to clone an object', function () {
-            var obj1 = {
-                    'first_name': 'Barney',
-                    'last_name': 'Stinson'
-                },
-                obj2 = obj1,
-                obj3 = clone(obj1);
+        var obj1, obj2, obj3;
 
+        beforeEach(function () {
+            obj1 = {
+                'first_name': 'Barney',
+                'last_name': 'Stinson',
+                'nested_object': {},
+                'nested_array': []
+            };
+            obj2 = obj1;
+            obj3 = clone(obj1);
+        });
+
+        it('should be able to clone an object', function () {
             expect(obj1).toBe(obj2);
             expect(obj3).not.toBe(obj1);
 
-            obj1['first_name'] = 'Ted';
-            obj1['last_name'] = 'Mosby';
+            obj3['first_name'] = 'Ted';
+            obj3['last_name'] = 'Mosby';
 
-            expect(obj2['first_name']).toBe('Ted');
-            expect(obj3['first_name']).toBe('Barney');
+            expect(obj1['first_name']).toEqual('Barney');
+            expect(obj2['first_name']).toEqual('Barney');
+            expect(obj3['first_name']).toEqual('Ted');
+        });
+
+        it('should clone with a nested object', function () {
+            expect(obj3['nested_object']).toEqual(obj1['nested_object']);
+        });
+
+        it('should clone with a nested array', function () {
+            expect(obj3['nested_array']).toEqual(obj1['nested_array']);
         });
     });
 });

--- a/tests/console-logger.spec.js
+++ b/tests/console-logger.spec.js
@@ -10,6 +10,7 @@ define([
 
         it('should default to use console log when type not passed', function () {
             spyOn(window.console, 'log');
+
             logger('I work');
 
             expect(window.console.log).toHaveBeenCalledWith('I work');
@@ -17,6 +18,7 @@ define([
 
         it('should use console error when specified', function () {
             spyOn(window.console, 'error');
+
             logger('AAAH ERROR to CONSOLE!', 'error');
 
             expect(window.console.error).toHaveBeenCalledWith('AAAH ERROR to CONSOLE!');
@@ -24,6 +26,7 @@ define([
 
         it('should fallback to use console log when passed type isn\'t accessible', function () {
             spyOn(window.console, 'log');
+
             logger('uhoh fallback to log!', 'someRandomConsoleMethod');
 
             expect(window.console.log).toHaveBeenCalledWith('uhoh fallback to log!');

--- a/tests/is-defined.spec.js
+++ b/tests/is-defined.spec.js
@@ -2,65 +2,81 @@ define([
     'aux/is-defined'
 ], function (isDefined) {
 
-    describe('Will check whether or not a variable is defined', function () {
+    describe('Will check whether or not a variable', function () {
 
-        it('should return that the variable is not defined', function () {
-            var check;
-            expect(isDefined(check)).toBeFalsy();
+        describe('is defined', function () {
+            it('should return that a variable is defined when a Function', function () {
+                var check = function () {};
+
+                expect(isDefined(check)).toBeTruthy();
+            });
+
+            it('should return that a variable is defined when an Object', function () {
+                expect(isDefined({})).toBeTruthy();
+            });
+
+            it('should return that a variable is defined when an Array', function () {
+                expect(isDefined([])).toBeTruthy();
+            });
+
+            it('should return that a variable is defined when a String', function () {
+                expect(isDefined('')).toBeTruthy();
+            });
+
+            it('should return that a variable is defined when a Number', function () {
+                expect(isDefined(1)).toBeTruthy();
+            });
+
+            it('should return that the variable is not defined', function () {
+                var check;
+
+                expect(isDefined(check)).toBeFalsy();
+            });
         });
 
-        it('should return that a variable is defined when an Object', function () {
-            var check = {};
-
-            expect(isDefined(check)).toBeTruthy();
-        });
-
-        it('should return that a variable is defined when an Array', function () {
-            var check = [];
-
-            expect(isDefined(check)).toBeTruthy();
-        });
-
-        it('should return that a variable is defined when a Number', function () {
-            var check = 1;
-
-            expect(isDefined(check)).toBeTruthy();
-        });
-
-        it('should return that a variable is defined when a Function', function () {
-            var check = function () {
-                };
-
-            expect(isDefined(check)).toBeTruthy();
-        });
-
-        describe('as a specific type', function () {
-            it('should return that a function is a defined as a function', function () {
-                var check = function () {
-                    };
+        describe('is a specific type', function () {
+            it('should return true if a function', function () {
+                var check = function () {};
 
                 expect(isDefined(check, 'function')).toBeTruthy();
             });
 
-            it('should return that a number is not a defined as a function', function () {
-                var check = 1;
-
-                expect(isDefined(check, 'function')).toBeFalsy();
+            it('should return true if an object', function () {
+                expect(isDefined({}, 'object')).toBeTruthy();
             });
 
-            it('should return that a number is defined as a number', function () {
-                var check = 1;
-
-                expect(isDefined(check, 'number')).toBeTruthy();
+            it('should return true if an array', function () {
+                expect(isDefined([], 'array')).toBeTruthy();
             });
 
-            it('should return that an array is not a number', function () {
-                var check = [];
+            it('should return true if a string', function () {
+                expect(isDefined('', 'string')).toBeTruthy();
+            });
 
-                expect(isDefined(check, 'number')).toBeFalsy();
+            it('should return true if a number', function () {
+                expect(isDefined(1, 'number')).toBeTruthy();
             });
         });
 
+        describe('is undefined or does not match type', function () {
+            it('should return that a number is not a function', function () {
+                expect(isDefined(1, 'function')).toBeFalsy();
+            });
+
+            it('should return that an array is not an object', function () {
+                expect(isDefined([], 'object')).toBeFalsy();
+            });
+
+            it('should return that an object is not an array', function () {
+                expect(isDefined({}, 'array')).toBeFalsy();
+            });
+
+            it('should return that an undefined variable is not an object', function () {
+                var check;
+
+                expect(isDefined(check, 'object')).toBeFalsy();
+            });
+        });
     });
 
 });


### PR DESCRIPTION
Fixes this issue:
```js
var obj = {
    'string': '',
    'array': []
  },
  c = clone(obj);

c.array; // {}
```
