### PR TITLE
Fix an issue where tap detection does not reference the correct event

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -63,18 +63,18 @@ define([
      */
     Touch.prototype._touchStartHandler = function (callback) {
         var $this = this;
-        return function (event) {
-            $this._preventDefault(event);
+        return function (event, data) {
+            $this._preventDefault(data);
 
-            var touch = event.targetTouches ? event.targetTouches[0] : event;
+            var touch = data.touches.length ? data.touches[0] : data;
             $this.touchStart = true;
             $this.cachedX = $this.currentX = touch.pageX;
             $this.cachedY = $this.currentY = touch.pageY;
 
-            if (event.type === 'touchstart') {
+            if (data.type === 'touchstart') {
                 setTimeout(function () {
                     if ($this._isTap()) {
-                        callback(event);
+                        callback(event, data);
                         $this._reset();
                     }
                 }, 200);

--- a/tests/touch.spec.js
+++ b/tests/touch.spec.js
@@ -6,6 +6,7 @@ define([
         var touch,
             mockEvent = {
                 preventDefault: function () {},
+                touches: [],
                 type: 'touchstart'
             };
 
@@ -48,7 +49,12 @@ define([
             var handler;
 
             beforeEach(function () {
+                jasmine.clock().install();
                 handler = touch._touchStartHandler(callback);
+            });
+
+            afterEach(function () {
+                jasmine.clock().uninstall();
             });
 
             it('should return a function', function () {
@@ -56,9 +62,23 @@ define([
             });
 
             it('should call prevent default', function () {
-                handler(mockEvent);
+                handler(jasmine.any(Object), mockEvent);
 
                 expect(touch._preventDefault).toHaveBeenCalledWith(mockEvent);
+            });
+
+            it('should callback if tap is detected', function () {
+                var ele = document.createElement('div');
+                touch.events.addListener(ele, 'touchstart', handler);
+                // Override tap detection
+                touch._isTap = function () {
+                    return true;
+                };
+
+                ele.ontouchstart(mockEvent);
+
+                jasmine.clock().tick(500);
+                expect(callback).toHaveBeenCalledWith(jasmine.any(Object), mockEvent);
             });
         });
 


### PR DESCRIPTION
The original `ontouchstart` event was not being passed correctly so `.pageX` and `.pageY` was undefined.