### PR TITLE
Use Scale via Transform

### DIFF
--- a/src/is-css-property-supported.js
+++ b/src/is-css-property-supported.js
@@ -1,0 +1,26 @@
+define([
+], function () {
+
+    /**
+     * Checks whether one or more properties are supported within the current browser
+     * @param {String} properties The CSS property (or properties seperated by spaces) in which to test
+     * @returns {Boolean} Whether one of the properties is supported within the browser
+     */
+    function isCssPropertySupported (properties) {
+        var cssProp = properties.split(' '),
+            supported = false;
+
+        for (var i = 0; i < cssProp.length; i++) {
+            // Check if the css property is attached to the style of the document body as an attribute
+            if (cssProp[i] in document.body.style) {
+                supported = true;
+                // We only want to ensure one is checked
+                break;
+            }
+        }
+
+        return supported;
+    }
+
+    return isCssPropertySupported;
+});

--- a/src/scale.js
+++ b/src/scale.js
@@ -1,12 +1,16 @@
 define([
-    'aux/events'
-], function (Events) {
+    'aux/attach-css',
+    'aux/events',
+    'aux/is-css-property-supported'
+], function (attachCss, Events, isCssPropertySupported) {
     /**
      * @exports scale
      *
      * Scale an element to fit the window
      *
+     * @requires module:attach-css
      * @requires module:events
+     * @requires module:is-css-property-supported
      */
     function Scale () {
         var events = new Events();
@@ -63,7 +67,17 @@ define([
                         ratio = window.innerHeight / height;
                     }
 
-                    node.style.zoom = ratio;
+                    if (isCssPropertySupported('transform -webkit-transform')) {
+                        var scale = 'scale(' + ratio + ')';
+                        attachCss(node, {
+                            transform: scale,
+                            '-webkit-transform': scale
+                        });
+                    } else {
+                        attachCss(node, {
+                            'zoom': ratio
+                        });
+                    }
                 };
             }
         };

--- a/tests/is-css-property-supported.spec.js
+++ b/tests/is-css-property-supported.spec.js
@@ -1,0 +1,17 @@
+define([
+    'aux/is-css-property-supported'
+], function (isCssPropertySupported) {
+    describe('Checking whether or not a browser supports a specific css property', function () {
+        it('should specify that the browser supports the property width', function () {
+            expect(isCssPropertySupported('width')).toBeTruthy();
+        });
+
+        it('should support multiple properties with one being valid', function () {
+            expect(isCssPropertySupported('one two another height broken')).toBeTruthy();
+        });
+
+        it('should specify that the browser doesn\'t support a property', function () {
+            expect(isCssPropertySupported('one random another')).toBeFalsy();
+        });
+    });
+});

--- a/tests/scale.spec.js
+++ b/tests/scale.spec.js
@@ -1,6 +1,7 @@
 define([
-    'aux/scale'
-], function (Scale) {
+    'aux/scale',
+    'aux/is-css-property-supported'
+], function (Scale, isCssPropertySupported) {
     describe('Scale module', function () {
         var node,
             scale;
@@ -35,7 +36,14 @@ define([
                 handler();
 
                 // Where empty string is the default zoom value
-                expect(node.style.zoom).not.toBe('');
+                if (isCssPropertySupported('transform -webkit-transform')) {
+                    var style = node.style,
+                        transform = (style.transform !== '') ? style.transform : style['-webkit-transform'];
+
+                    expect(transform).toContain('scale(');
+                } else {
+                    expect(node.style.zoom).not.toBe('');
+                }
             });
         });
     });


### PR DESCRIPTION
- Change the current way in which scale is done (using CSS Zoom) to use the CSS3 ``transform: scale(x)``.
- Defaults to ``zoom`` if ``transform`` is unusable
- Adds in a helper for checking whether a specific CSS property is useable within the current browser.
