### PR TITLE
Allow createElement to have a document passed in which to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ console.log (again if accessible).
 
 - tag `string` - The HTML tag type in which to create  
 - params `object` - Contains paramaters to be used for the creation of the element  
+- doc `object` - Optionally pass the document in which to create the element apart of  
 
 **Properties**
 
@@ -254,7 +255,7 @@ var childEle = createElement('div'),
 	   	childEle
 	   ]
     },
-    ele = createElement('div', params);
+    ele = createElement('div', params, top.document);
 // Ele becomes
 // <div style="border: 1px solid black; background-color: red;" class="legen wait-for-it dary">
 //   <div class="simpsons"><span class="bart"></span></div>
@@ -711,20 +712,21 @@ removeElement(myParent, true)
   **Members**
 
 * [scale](#module_scale)
-  * [scale.init(window, node, width, height)](#module_scale.init)
-  * [scale._scaleHandler(window, node, width, height)](#module_scale._scaleHandler)
+  * [scale.init(win, node, width, height, fullscreen)](#module_scale.init)
+  * [scale._scaleHandler(win, node, width, height, fullscreen)](#module_scale._scaleHandler)
 
 <a name="module_scale.init"></a>
-####scale.init(window, node, width, height)
+####scale.init(win, node, width, height, fullscreen)
 Will scale the element to the size of the window, ensuring that it doesn't exceed the max
 width and height.
 
 **Params**
 
-- window `Object` - Window object that we will resize to  
+- win `Object` - Window object that we will resize to  
 - node `Object` - Element to apply scale to  
 - width `Number` - The elements max-width  
 - height `Number` - The elements max-height  
+- fullscreen `Boolean` - Whether to scale to the fullscreen (going over the original width and height)  
 
 **Example**  
 ```js
@@ -736,15 +738,16 @@ scale.init(htmlNode, 600, 400);
 ```
 
 <a name="module_scale._scaleHandler"></a>
-####scale._scaleHandler(window, node, width, height)
+####scale._scaleHandler(win, node, width, height, fullscreen)
 Returns a function to be used for listening to events.
 
 **Params**
 
-- window `Object` - Window object that we will resize to  
+- win `Object` - Window object that we will resize to  
 - node `Object` - Element to apply scale to  
-- width `Number` - Creative width  
-- height `Number` - Creative height  
+- width `Number` - Node width  
+- height `Number` - Node height  
+- fullscreen `Boolean` - Whether to scale to the fullscreen (going over the original width and height)  
 
 **Returns**: `function` - Event handler  
 **Access**: protected  

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -22,6 +22,7 @@ define([
      * @property {string} params.innerHTML A string representation of DOM elements to attach as children to the ele
      * @property {array} params.nodes An array containing elements to create as children
      * @property {array} params.children An array of HTMLNodes to append as children to the element
+     * @param {object} doc Optionally pass the document in which to create the element apart of
      *
      * @returns ele The HTML element created with css and attributes added to passed from params
      *
@@ -57,7 +58,7 @@ define([
      * 	   	childEle
      * 	   ]
      *     },
-     *     ele = createElement('div', params);
+     *     ele = createElement('div', params, top.document);
      * // Ele becomes
      * // <div style="border: 1px solid black; background-color: red;" class="legen wait-for-it dary">
      * //   <div class="simpsons"><span class="bart"></span></div>
@@ -67,8 +68,9 @@ define([
      * // Clicking on the main div will console log
      * ```
      */
-    function createElement (tag, params) {
-        var ele = document.createElement(tag),
+    function createElement (tag, params, doc) {
+        doc = doc || document;
+        var ele = doc.createElement(tag),
             inner;
 
         if (typeof params === 'undefined') {
@@ -89,7 +91,7 @@ define([
             inner = params.nodes;
 
             for (var i = 0; i < inner.length; i++) {
-                ele.appendChild(createElement(inner[i].tag, inner[i]));
+                ele.appendChild(createElement(inner[i].tag, inner[i], doc));
             }
         }
 

--- a/tests/create-element.spec.js
+++ b/tests/create-element.spec.js
@@ -10,6 +10,21 @@ define([
             expect(ele.tagName).toBeIgnoreCase('div');
         });
 
+        it('should create an element as part of a specific document', function () {
+            var customDocument = {
+                    createElement: function () {
+                        return true;
+                    }
+                },
+                ele;
+
+            spyOn(customDocument, 'createElement');
+
+            ele = createElement('div', {}, customDocument);
+
+            expect(customDocument.createElement).toHaveBeenCalled();
+        });
+
         it('should attach inline styling if passed through params', function () {
             var params = {
                     css: {


### PR DESCRIPTION
When creating an element allow the element to be created as part of a particular document https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType