### PR TITLE
Fixes a bug where all information not returned

### DIFF
--- a/src/get-url-info.js
+++ b/src/get-url-info.js
@@ -35,7 +35,19 @@ define([
      * ```
      */
     function getUrlInfo (url) {
+        if (!url) {
+            return;
+        }
+
         var linkInfo;
+
+        if (url.indexOf('//') === 0) {
+            // Check if the url is protocoless and if so attach a protocol on in order to get all of the information
+            url = 'http:' + url;
+        } else if (url.indexOf('http') === -1) {
+            // Ensure that the url contains a protocol otherwise it will not be possible to get all of the information
+            url = 'http://' + url;
+        }
 
         try {
             // Try to use the built in browser URL functions

--- a/tests/get-url-info.spec.js
+++ b/tests/get-url-info.spec.js
@@ -35,5 +35,25 @@ define([
         it('should return the search', function () {
             expect(getUrlInfo(url).search).toBe('?a=foo&b=bar');
         });
+
+        it('should return null when url is blank', function () {
+            url = '';
+
+            expect(getUrlInfo(url)).toBeUndefined();
+        });
+
+        it('should deal with a protocoless url', function () {
+            url = url.split('https:')[1];
+
+            expect(getUrlInfo(url).hostname).toBe('www.some-example.com');
+            expect(getUrlInfo(url).href).toContain(url);
+        });
+
+        it('should deal with no protocol at all on url', function () {
+            url = url.split('https://')[1];
+
+            expect(getUrlInfo(url).hostname).toBe('www.some-example.com');
+            expect(getUrlInfo(url).href).toContain(url);
+        });
     });
 });


### PR DESCRIPTION
When using the ``new URL`` feature the url needs to contain the protocol otherwise the browser will not deem it a valid url and mean that you can't get all the information back from the module (hostname, host etc.)