### PR TITLE
Return the original window when no parent access

### DIFF
--- a/src/get-highest-accessible-window.js
+++ b/src/get-highest-accessible-window.js
@@ -28,6 +28,7 @@ define([
      */
     function getHighestAccessibleWindow (win) {
         win = win || window;
+        parent = win;
 
         // Check to see if we have access to the top level window
         try {

--- a/tests/get-highest-accessible-window.spec.js
+++ b/tests/get-highest-accessible-window.spec.js
@@ -51,5 +51,11 @@ define([
 
             expect(getHighestAccessibleWindow(win).document.domain).toBe('woops');
         });
+
+        it('should return the current window if we do not have access to any of it\'s parents', function () {
+            win.parent.parent.document = false;
+
+            expect(getHighestAccessibleWindow(win)).toBe(win);
+        });
     });
 });


### PR DESCRIPTION
When calling the `getHighestAccessibleWindow` we should return the original `window` scope if there are no parent's in which we have access.