### PR TITLE
Parallax scrolling uses Offset module

### DIFF
--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -1,6 +1,7 @@
 define([
-    'aux/attach-css'
-], function (attachCss) {
+    'aux/attach-css',
+    'aux/offset'
+], function (attachCss, offset) {
 
     /**
      * Scroll an HTML element at a different rate to the browsers scroll ensuring that all of the element's content
@@ -30,20 +31,12 @@ define([
         invert = invert || false;
 
         var offsetTop = win.pageYOffset,
-            container = ele.parentNode,
             distance = (win.innerHeight - viewableHeight),
             scrollDistance = (eleHeight - viewableHeight),
-            top = container.offsetTop,
+            top = offset(ele.parentNode).y,
             ratio,
             margin,
             css = {};
-
-        // When we are within a nested element we need to check the offset of the parent and ensure we take the top
-        // offset of that element in to consideration when checking scrolling our element
-        while (container.offsetParent) {
-            container = container.offsetParent;
-            top += container.offsetTop;
-        }
 
         // Check that the htmlNode is fully within the viewport before starting to scroll
         if (offsetTop < top && (offsetTop + distance) > top) {

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -30,8 +30,9 @@ define([
         // Whether or not to use inverted scrolling direction (defaulting to normal direction)
         invert = invert || false;
 
-        var offsetTop = win.pageYOffset,
-            distance = (win.innerHeight - viewableHeight),
+        var offsetTop = win.pageYOffset || win.document.documentElement.scrollTop,
+            winHeight = win.innerHeight || win.document.documentElement.clientHeight,
+            distance = (winHeight  - viewableHeight),
             scrollDistance = (eleHeight - viewableHeight),
             top = offset(ele.parentNode).y,
             ratio,


### PR DESCRIPTION
- Move to use the offset module within parallax
- IE8 fix `win.pageYOffset` & `win.innerHeight` isn't supported in `IE8` moves to use an equivalent

TP: https://rockabox.tpondemand.com/entity/10382