### PR TITLE
Fixes a bug where scroll distance was never passed.

### DIFF
--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -64,7 +64,7 @@ define([
         } else if ((scrollTop + distance) <= offsetTop) {
             if (this.invert) {
                 // Set the element to show from the bottom of the content (when inverted and at the top)
-                margin = this._positionBottom(this._scrollDistance);
+                margin = this._positionBottom(scrollDistance);
             } else {
                 // Set the element to show from the top of the content (when not inverted and at the top)
                 margin = this._positionTop();
@@ -75,7 +75,7 @@ define([
                 margin = this._positionTop();
             } else {
                 // Set the element to show from the bottom of the content (when not inverted and at the top)
-                margin = this._positionBottom(this._scrollDistance);
+                margin = this._positionBottom(scrollDistance);
             }
         }
 


### PR DESCRIPTION
``$this._scrollDistance`` is old code and is no longer attached to the instance and instead passed via the helper. This fixes a bug where the element would always show the top when not fully in view.

TP: https://rockabox.tpondemand.com/entity/10252