### PR TITLE
Pass window event if event is null

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -63,6 +63,7 @@ define([
             }
             // Replace with our own
             ele['on' + eventType] = function (event) {
+                event = event || window.event;
                 $this.handleEvent(ele, {
                     type: eventType
                 }, event);


### PR DESCRIPTION
When triggering an event on the window object within IE8 an event is not always passed to the function, get the event from the window in this case.