### PR TITLE
Parallax overriding the offset and window object

### DIFF
--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -208,8 +208,12 @@ define([
             scrollDistance = (eleHeight - viewableHeight);
 
         // The handler in which to be used for firing when scrolling
-        return function () {
-            var winPosition = $this._getWindowPositions(win),
+        // Allows passing a new window object through the handler and the offset of the container
+        return function (overrideWin, overrideOffset) {
+            overrideWin = overrideWin || win;
+            overrideOffset = overrideOffset || offsetTop;
+
+            var winPosition = $this._getWindowPositions(overrideWin),
                 margin = 0,
                 distance,
                 scrollTop = winPosition.scrollTop;
@@ -217,7 +221,7 @@ define([
             // Set the distance of the viewable height compared to the position of the window height
             distance = (winPosition.winHeight  - viewableHeight);
 
-            margin = $this._getMargin(offsetTop, scrollDistance, distance, scrollTop);
+            margin = $this._getMargin(overrideOffset, scrollDistance, distance, scrollTop);
             $this._setElePosition(ele, margin);
 
             return margin;

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -1,7 +1,8 @@
 define([
     'aux/attach-css',
+    'aux/has-property',
     'aux/offset'
-], function (attachCss, offset) {
+], function (attachCss, hasProperty, offset) {
 
     /**
      * Scroll an HTML element at a different rate to the browsers scroll ensuring that all of the element's content
@@ -123,9 +124,12 @@ define([
      *
      */
     ParallaxScrolling.prototype._getWindowPositions = function (win) {
+        var pageYOffset = hasProperty(win, 'pageYOffset') ? win.pageYOffset : win.document.documentElement.scrollTop,
+            innerHeight = hasProperty(win, 'innerHeight') ? win.innerHeight : win.document.documentElement.clientHeight;
+
         return {
-            scrollTop:  win.pageYOffset || win.document.documentElement.scrollTop,
-            winHeight: win.innerHeight || win.document.documentElement.clientHeight
+            scrollTop:  pageYOffset,
+            winHeight: innerHeight
         };
     };
 

--- a/tests/parallax-scrolling.spec.js
+++ b/tests/parallax-scrolling.spec.js
@@ -40,6 +40,40 @@ define([
             expect(parallaxScrolling._offset).toHaveBeenCalledWith(container);
         });
 
+        describe('overriding variables via handler', function () {
+            it('should allow overriding of the window', function () {
+                spyOn(parallaxScrolling, '_getWindowPositions').and.callThrough();
+
+                var handler = parallaxScrolling.init(ele, container, 100, 50),
+                    overrideWin = {
+                        pageYOffset: 10,
+                        innerHeight: 30,
+                        document: {
+                            documentElement: {
+                                scrollTop: 10,
+                                clientHeight: 30
+                            }
+                        }
+                    };
+
+                handler(overrideWin);
+
+                expect(parallaxScrolling._getWindowPositions).toHaveBeenCalledWith(overrideWin);
+            });
+
+            it('should allow overriding of the offset', function () {
+                parallaxScrolling._getMargin = function (offsetTop) {
+                    return offsetTop;
+                };
+
+                var overrideWin,
+                    handler = parallaxScrolling.init(ele, container, 100, 50),
+                    margin = handler(overrideWin, 20192);
+
+                expect(margin).toBe(20192);
+            });
+        });
+
         describe('window positions', function () {
             it('should get how much the current document has been scrolled', function () {
                 var windowPosition = parallaxScrolling._getWindowPositions(window);


### PR DESCRIPTION
In the case of using Parallax within an iframe, this allows the parallax helper to be setup on the window iframe but overriding the window information (`pageYOffset` & `innerHeight`) once the helper has already been setup.

TP: https://rockabox.tpondemand.com/entity/10299