### PR TITLE
Allow swiping past an element

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -122,7 +122,6 @@ define([
         this.events.addListeners(ele, 'click', endHandler);
 
         this.events.addListeners(ele, 'touchstart', function (rbEvent, event) {
-            rbEvent.preventDefault();
             startHandler(rbEvent, event);
         });
 


### PR DESCRIPTION
Prevent default on touchstart prevents the browsers normal scrolling.

TP: https://rockabox.tpondemand.com/entity/10730