### PR TITLE
Fire percentage viewable

### DIFF
--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -53,6 +53,26 @@ define([
     ParallaxScrolling.prototype._events = events;
 
     /**
+     * Get the percent of content showing within the viewport
+     *
+     * @memberOf: parallax-scrolling
+     *
+     * @param  {Number} scrollTop The offset top of the current viewport compared to the window.
+     * @param  {Number} viewportHeight The height of the viewport.
+     * @param  {Number} offsetTop The offsetTop offset of the element.
+     * @param  {Number} eleHeight The height of the element.
+     * @return {Number}           The percentage of the element that is currently within view.
+     */
+    ParallaxScrolling.prototype._getViewportPercent = function (scrollTop, viewportHeight, offsetTop, eleHeight) {
+        var distance = (scrollTop + viewportHeight) - offsetTop,
+            percentage = distance / ((viewportHeight + eleHeight) / 100);
+
+        percentage = Math.round(percentage);
+
+        return percentage;
+    };
+
+    /**
      * Get the scrollY position of the element depending on the current viewport
      *
      * @memberOf module:parallax-scrolling

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -339,19 +339,23 @@ define([
 
             var winPosition = $this._getWindowPositions(overrideWin),
                 scrollY = 0,
-                distance,
+                // Set the distance of the viewable height compared to the position of the window height
+                distance = (winPosition.winHeight - viewableHeight),
                 scrollTop = winPosition.scrollTop,
-                percentage;
-
-            // Set the distance of the viewable height compared to the position of the window height
-            distance = (winPosition.winHeight  - viewableHeight);
+                percentage,
+                position = $this._getViewportPosition(overrideOffset, distance, scrollTop);
 
             // Get the scrollY position of the content and use it.
             scrollY = $this._getScrollY(overrideOffset, scrollDistance, distance, scrollTop);
             $this._setElePosition(ele, scrollY);
 
-            // Get the percentage of the parallaxed content that is currently viewable.
-            percentage = $this._getPercentageViewed(scrollY, eleHeight, viewableHeight, invert);
+            if (position === 'bottom') {
+                percentage = $this._getViewportPercent(scrollTop, winPosition.winHeight, offsetTop, viewableHeight);
+            } else {
+                // Get the percentage of the parallaxed content that is currently viewable.
+                percentage = $this._getPercentageViewed(scrollY, eleHeight, viewableHeight, invert, scrollTop);
+            }
+
             // Pass the percentage with no decimal places to the scroll percentage trigger.
             $this._scrollPercentTriggers(ele, percentage);
 

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -79,6 +79,7 @@ define([
      *
      * @private
      *
+     * @param  {String} position  The position of the htmlNode (top of view, bottom of view or in centre (in view))
      * @param  {Number} offsetTop The offsetTop offset of the element.
      * @param  {Number} scrollDistance The distance of the viewable height compared to the position of the window height
      * @param  {Number} distance  The distance between the windows height and the viewable height.
@@ -86,32 +87,23 @@ define([
      *
      * @return {Number} The scrollY position of the what the element should be
      */
-    ParallaxScrolling.prototype._getScrollY = function (offsetTop, scrollDistance, distance, scrollTop) {
+    ParallaxScrolling.prototype._getScrollY = function (position, offsetTop, scrollDistance, distance, scrollTop) {
         var ratio,
             scrollY;
 
-        // Check that the htmlNode is fully within the viewport before starting to scroll
-        if (scrollTop < offsetTop && (scrollTop + distance) > offsetTop) {
+        if ((position === 'top' && this.invert) || (position === 'bottom' && !this.invert)) {
+            // Set the element to show from the top when the htmlNode is at the top of the viewport with invert on or
+            // the htmlNode is at the bottom invert is off.
+            scrollY = this._positionTop();
+        } else if ((position === 'top' && !this.invert) || (position === 'bottom' && this.invert)) {
+            // Set the element to show the bottom of the content when the htmlNode is at the top of the viewport when
+            // invert is on or the htmlNode is at the bottom when invert is off.
+            scrollY = this._positionBottom(scrollDistance);
+        } else {
             // Gets the ratio (scroll speed) to be able to show all of the element within the viewable height, dependant
             // on the viewport size.
             ratio = this._getRatio(offsetTop, scrollTop, distance, this.invert);
             scrollY = -Math.abs(scrollDistance * ratio);
-        } else if ((scrollTop + distance) <= offsetTop) {
-            if (this.invert) {
-                // Set the element to show from the bottom of the content (when inverted and at the top)
-                scrollY = this._positionBottom(scrollDistance);
-            } else {
-                // Set the element to show from the top of the content (when not inverted and at the top)
-                scrollY = this._positionTop();
-            }
-        } else {
-            if (this.invert) {
-                // Set the element to show from the top of the content (when inverted and at the top)
-                scrollY = this._positionTop();
-            } else {
-                // Set the element to show from the bottom of the content (when not inverted and at the top)
-                scrollY = this._positionBottom(scrollDistance);
-            }
         }
 
         return scrollY;
@@ -346,7 +338,7 @@ define([
                 position = $this._getViewportPosition(overrideOffset, distance, scrollTop);
 
             // Get the scrollY position of the content and use it.
-            scrollY = $this._getScrollY(overrideOffset, scrollDistance, distance, scrollTop);
+            scrollY = $this._getScrollY(position, overrideOffset, scrollDistance, distance, scrollTop);
             $this._setElePosition(ele, scrollY);
 
             if (position === 'bottom') {

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -256,6 +256,35 @@ define([
     };
 
     /**
+     * Get the current viewport position (top, centre or bottom)
+     * NOTE: top will mean that part of the content is out of view at the top of the viewport, centre will mean that
+     * all of the element is currently within the viewport and bottom will mean that part of the content is out of view
+     * at the bottom.
+     *
+     * @memberOf module:parallax-scrolling
+     *
+     * @param  {Number} offsetTop The offsetTop offset of the element.
+     * @param  {Number} distance  The distance between the windows height and the viewable height.
+     * @param  {Number} scrollTop The offset top of the current viewport compared to the window.
+     *
+     * @return {String}           Where the htmlNode is currently in view
+     */
+    ParallaxScrolling.prototype._getViewportPosition = function (offsetTop, distance, scrollTop) {
+
+        // Check that the htmlNode is fully within the viewport before starting to scroll
+        if (scrollTop < offsetTop && (scrollTop + distance) > offsetTop) {
+            // We are in full view
+            return 'centre';
+        } else if ((scrollTop + distance) <= offsetTop) {
+            // We are at the top of the page
+            return 'bottom';
+        } else {
+            // We are at the bottom of the page
+            return 'top';
+        }
+    };
+
+    /**
      * Initialise the a new parallax scrolling handler
      *
      * @memberOf module:parallax-scrolling

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -41,7 +41,7 @@ define([
     function ParallaxScrolling () {
         this._attachCss = attachCss;
         this._offset = offset;
-        this._lastPercent = 0;
+        this._lastPercent = -1;
     }
 
     /**

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -239,7 +239,7 @@ define([
      * @return {Boolean}           Whether the percentage was triggered or not.
      */
     ParallaxScrolling.prototype._scrollPercentTriggers = function (ele, percentage) {
-        var roundedPercent = (parseInt(Math.floor(percentage) / 10, 10) * 10),
+        var roundedPercent = Math.floor(percentage / 10) * 10,
             triggered = false;
 
         if (roundedPercent !== this._lastPercent) {

--- a/tests/parallax-scrolling.spec.js
+++ b/tests/parallax-scrolling.spec.js
@@ -342,6 +342,49 @@ define([
             });
         });
 
+        describe('getting of the element in view', function () {
+            var scrollTop,
+                viewportHeight,
+                offsetTop,
+                eleHeight;
+
+            it('should return that 25% is in view', function () {
+                scrollTop = 0;
+                viewportHeight = 100;
+                offsetTop = 50;
+                eleHeight = 100;
+
+                percent = ParallaxScrolling.prototype.
+                            _getViewportPercent(scrollTop, viewportHeight, offsetTop, eleHeight);
+
+                expect(percent).toBe(25);
+            });
+
+            it('should return that 50% is in view', function () {
+                scrollTop = 50;
+                viewportHeight = 100;
+                offsetTop = 50;
+                eleHeight = 100;
+
+                percent = ParallaxScrolling.prototype.
+                            _getViewportPercent(scrollTop, viewportHeight, offsetTop, eleHeight);
+
+                expect(percent).toBe(50);
+            });
+
+            it('should return that 100% is in view', function () {
+                scrollTop = 150;
+                viewportHeight = 100;
+                offsetTop = 50;
+                eleHeight = 100;
+
+                percent = ParallaxScrolling.prototype.
+                            _getViewportPercent(scrollTop, viewportHeight, offsetTop, eleHeight);
+
+                expect(percent).toBe(100);
+            });
+        });
+
         describe('triggering events for content viewable percentages', function () {
             var triggerEvent;
 

--- a/tests/parallax-scrolling.spec.js
+++ b/tests/parallax-scrolling.spec.js
@@ -138,6 +138,60 @@ define([
             });
         });
 
+        describe('getting the position within the viewport', function () {
+            var scrollTop,
+                distance,
+                offsetTop,
+                position;
+
+            it('should return that the content is at the top of the view port', function () {
+                scrollTop = 50;
+                offsetTop = 49;
+                distance = 99;
+                position = ParallaxScrolling.prototype._getViewportPosition(offsetTop, distance, scrollTop);
+
+                expect(position).toBe('top');
+            });
+
+            describe('centre of viewport', function () {
+                it('should return that the content is at the centre of the view port', function () {
+                    scrollTop = 50;
+                    offsetTop = 80;
+                    distance = 31;
+                    position = ParallaxScrolling.prototype._getViewportPosition(offsetTop, distance, scrollTop);
+
+                    expect(position).toBe('centre');
+                });
+
+                it('should not return when scrolled passed', function () {
+                    scrollTop = 50;
+                    offsetTop = 49;
+                    distance = 40;
+                    position = ParallaxScrolling.prototype._getViewportPosition(offsetTop, distance, scrollTop);
+
+                    expect(position).not.toBe('centre');
+                });
+
+                it('should not return that it is centre not scrolled enough', function () {
+                    scrollTop = 50;
+                    offsetTop = 80;
+                    distance = 29;
+                    position = ParallaxScrolling.prototype._getViewportPosition(offsetTop, distance, scrollTop);
+
+                    expect(position).not.toBe('centre');
+                });
+            });
+
+            it('should return that the content is within the centre of the view port', function () {
+                offsetTop = 101;
+                scrollTop = 100;
+                distance = 1;
+                position = ParallaxScrolling.prototype._getViewportPosition(offsetTop, distance, scrollTop);
+
+                expect(position).toBe('bottom');
+            });
+        });
+
         it('should set the marginal position to an element', function () {
             spyOn(parallaxScrolling, '_attachCss');
 

--- a/tests/parallax-scrolling.spec.js
+++ b/tests/parallax-scrolling.spec.js
@@ -1,14 +1,16 @@
 define([
-    'aux/create-element',
-    'aux/parallax-scrolling'
-], function (createElement, ParallaxScrolling) {
-    var container,
+    'aux/create-element'
+], function (createElement) {
+    var ParallaxScrolling,
+        container,
         ele,
         mainEle,
         parallaxScrolling;
 
     describe('Parallax scrolling an element', function () {
         beforeEach(function () {
+            ParallaxScrolling = require('aux/parallax-scrolling');
+
             ele = document.createElement('div');
             mainEle = document.createElement('div');
             container = createElement('div', {
@@ -62,7 +64,7 @@ define([
             });
 
             it('should allow overriding of the offset', function () {
-                parallaxScrolling._getScrollY = function (offsetTop) {
+                parallaxScrolling._getScrollY = function (position, offsetTop) {
                     return offsetTop;
                 };
 
@@ -71,6 +73,126 @@ define([
                     scrollY = handler(overrideWin, 20192);
 
                 expect(scrollY).toBe(20192);
+            });
+        });
+
+        describe('getting the scroll y position', function () {
+            var position,
+                offsetTop,
+                scrollDistance,
+                distance,
+                scrollTop,
+                scrollY;
+
+            beforeEach(function () {
+                offsetTop = 90;
+                scrollDistance = 100;
+                distance = 40;
+                scrollTop = 10;
+            });
+
+            describe('top of viewport', function () {
+                beforeEach(function () {
+                    position = 'top';
+                });
+
+                it('should return the scroll y position as the top when normal scrolling', function () {
+                    spyOn(ParallaxScrolling.prototype, '_positionTop').and.returnValue('topPosition');
+
+                    ParallaxScrolling.prototype.invert = true;
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._positionTop).toHaveBeenCalled();
+                    expect(scrollY).toBe('topPosition');
+                });
+
+                it('should return the scroll y with content ready to view the bottom when inverted', function () {
+                    scrollDistance = 100;
+
+                    spyOn(ParallaxScrolling.prototype, '_positionBottom').and.returnValue('bottomPosition');
+
+                    ParallaxScrolling.prototype.invert = false;
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._positionBottom).toHaveBeenCalledWith(scrollDistance);
+                    expect(scrollY).toBe('bottomPosition');
+                });
+            });
+
+            describe('bottom of viewport', function () {
+                beforeEach(function () {
+                    postion = 'bottom';
+                });
+
+                it('should return scroll y to show bottom content when at bottom scrolling normally', function () {
+                    spyOn(ParallaxScrolling.prototype, '_positionBottom').and.returnValue('bottomPosition');
+
+                    ParallaxScrolling.prototype.invert = false;
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._positionBottom).toHaveBeenCalledWith(scrollDistance);
+                    expect(scrollY).toBe('bottomPosition');
+                });
+
+                it('should return scroll y to show top content when at bottom scrolling invertedly', function () {
+                    spyOn(ParallaxScrolling.prototype, '_positionTop').and.returnValue('topPosition');
+
+                    ParallaxScrolling.prototype.invert = true;
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._positionTop).toHaveBeenCalled();
+                    expect(scrollY).toBe('topPosition');
+                });
+            });
+
+            describe('centre of viewport', function () {
+                beforeEach(function () {
+                    position = 'center';
+
+                    ParallaxScrolling.prototype.invert = false;
+                });
+
+                it('should not call top or bottom position helpers', function () {
+                    spyOn(ParallaxScrolling.prototype, '_positionTop').and.returnValue('top');
+                    spyOn(ParallaxScrolling.prototype, '_positionBottom').and.returnValue('bottom');
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._positionTop).not.toHaveBeenCalled();
+                    expect(ParallaxScrolling.prototype._positionBottom).not.toHaveBeenCalled();
+                });
+
+                it('should call get ratio', function () {
+                    spyOn(ParallaxScrolling.prototype, '_getRatio').and.returnValue(0.8);
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(ParallaxScrolling.prototype._getRatio).toHaveBeenCalledWith(
+                        offsetTop,
+                        scrollTop,
+                        distance,
+                        false
+                    );
+                });
+
+                it('should return the scroll y with the ratio times by the scroll distance as a minus', function () {
+                    spyOn(ParallaxScrolling.prototype, '_getRatio').and.returnValue(0.8);
+
+                    scrollY = ParallaxScrolling.prototype.
+                                _getScrollY(position, offsetTop, scrollDistance, distance, scrollTop);
+
+                    expect(scrollY).toBe(-80);
+                });
             });
         });
 


### PR DESCRIPTION
Will trigger an event based on the percentage of the content that is in view, when the the entire element is not in view it will trigger based on the content in the view port. It will trigger in percentiles of 10 (11% would trigger 10% if 10% has not previously been fired due to fast scrolling etc.)

TP: https://rockabox.tpondemand.com/entity/11184