### PR TITLE
Add threshold when detecting tap events.

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -14,6 +14,7 @@ define([
         this.touchStartY = 0;
         // Sets the thresholds of interaction types
         this.swipeDistance = 10;
+        this.threshold = 5;
     }
 
     /**
@@ -26,7 +27,10 @@ define([
      * @return {Boolean} True if position is the same.
      */
     Touch.prototype._isTap = function (posX, posY) {
-        return (this.touchStartX === posX) && (this.touchStartY === posY);
+        var x = Math.abs(this.touchStartX - posX),
+            y = Math.abs(this.touchStartY - posY);
+
+        return (x < this.threshold) && (y < this.threshold);
     };
 
     /**

--- a/tests/touch.spec.js
+++ b/tests/touch.spec.js
@@ -10,11 +10,24 @@ define([
             callback = jasmine.createSpy('callback');
         });
 
-        it('should be able to detect isTap', function () {
-            touch.touchStartX = 10;
-            touch.touchStartY = 40;
-            expect(touch._isTap(10, 40)).toBeTruthy();
-            expect(touch._isTap(40, 10)).toBeFalsy();
+        describe('_isTap', function () {
+            beforeEach(function () {
+                touch.touchStartX = 10;
+                touch.touchStartY = 40;
+            });
+
+            it('should be detected', function () {
+                expect(touch._isTap(10, 40)).toBeTruthy();
+                expect(touch._isTap(40, 10)).toBeFalsy();
+            });
+
+            it('should be detected if within the threshold of 5', function () {
+                expect(touch._isTap(12, 43)).toBeTruthy();
+            });
+
+            it('should not be detected if outside the threshold of 5', function () {
+                expect(touch._isTap(15, 46)).toBeFalsy();
+            });
         });
 
         it('should be able to detect isSwipe', function () {


### PR DESCRIPTION
A Sony device will return coordinates as a float therefore the start and end coordinates are rarely exactly the same. Adding a threshold of 5 to compensate for this accuracy issue.

TP: https://rockabox.tpondemand.com/entity/11049