### PR TITLE
Using typeof instead of boolean check in onerror

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A webpacked utility library.",
   "author": [
     "Rockabox <tech@rockabox.com> (http://rockabox.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-chrome-launcher": "~0.1.7",
     "karma-coverage": "~0.2.7",
     "karma-firefox-launcher": "~0.1.4",
-    "karma-jasmine": "~0.3.5",
+    "karma-jasmine": "0.3.5",
     "karma-sauce-launcher": "~0.2.10",
     "karma-webpack": "~1.5.0",
     "load-grunt-config": "~0.16.0",

--- a/src/load-script.js
+++ b/src/load-script.js
@@ -25,7 +25,8 @@ define([
         this.addListeners = function (onload, onerror) {
             onLoadHandler = onload;
             script.onload = script.onreadystatechange = $this.onload;
-            if (script.onerror) {
+
+            if (typeof script.onerror !== 'undefined') {
                 script.onerror = onerror;
             }
 


### PR DESCRIPTION
When checking for the presence of `onerror` dont use Boolean check, use typeof, as it is `null` (at least on firefox)