### PR TITLE
Add multi-ajax

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,57 @@ Creates a DOM element for the script tag.
 **Returns**: `object` - Merged object  
 
 
+# multi-ajax
+  A module to perform several AJAX calls
+
+**Members**
+
+* [multi-ajax](#module_multi-ajax)
+  * [multi-ajax.MultiAjax#_loadJsonCallbackGenerator(urls, index, method, onload, onerror, responses)](#module_multi-ajax.MultiAjax#_loadJsonCallbackGenerator)
+  * [multi-ajax.MultiAjax#_loadJson(urls, index, method, onload, onerror, responses)](#module_multi-ajax.MultiAjax#_loadJson)
+  * [multi-ajax.MultiAjax#loadJson(urls, method, onload, onerror)](#module_multi-ajax.MultiAjax#loadJson)
+
+<a name="module_multi-ajax.MultiAjax#_loadJsonCallbackGenerator"></a>
+####multi-ajax.MultiAjax#_loadJsonCallbackGenerator(urls, index, method, onload, onerror, responses)
+Return a function that can be used as a callback for the Json loading requests.
+
+**Params**
+
+- urls `Array.<string>` - Location of json files  
+- index `integer` - Index of the url being processed  
+- method `string` - Defaults to get  
+- onload `function` - Success callback  
+- onerror `function` - Error callback  
+- responses `Array.<Object>` - Partial response, array containing all the responses collected by previous requests  
+
+**Access**: protected  
+<a name="module_multi-ajax.MultiAjax#_loadJson"></a>
+####multi-ajax.MultiAjax#_loadJson(urls, index, method, onload, onerror, responses)
+Request and parse a single Json object, using a generated callback to collect the response.
+
+**Params**
+
+- urls `Array.<string>` - Location of json files  
+- index `integer` - Index of the url being processed  
+- method `string` - Defaults to get  
+- onload `function` - Success callback  
+- onerror `function` - Error callback  
+- responses `Array.<Object>` - Partial response, array containing all the responses collected by previous requests  
+
+**Access**: protected  
+<a name="module_multi-ajax.MultiAjax#loadJson"></a>
+####multi-ajax.MultiAjax#loadJson(urls, method, onload, onerror)
+Execute several ajax requests parsing the responses into a list of JSON objects.
+
+**Params**
+
+- urls `Array.<string>` - Location of json files  
+- method `string` - Defaults to get  
+- onload `function` - Success callback  
+- onerror `function` - Error callback  
+
+
+
 # offset
   Gets the X and Y offset of an element to the current window and whether or not the element is positioned within
 a fixed element.

--- a/docs/readme.hb
+++ b/docs/readme.hb
@@ -193,6 +193,12 @@ define([
   {{>exported~}}
 {{/module}}
 
+{{#module name="multi-ajax"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}
+
 {{#module name="offset"~}}
   # {{>name}}
   {{>body~}}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-karma": "~0.10.1",
     "grunt-karma-coveralls": "~2.5.3",
     "istanbul-instrumenter-loader": "~0.1.2",
+    "jasmine-ajax": "~3.2.0",
     "jasmine-core": "~2.2.0",
     "jsdoc-to-markdown": "~0.5.11",
     "karma": "~0.12.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -51,15 +51,15 @@ define([
          */
         getRequest: function () {
             var xhr = false;
-            if (typeof XDomainRequest !== 'undefined') {
+            if (typeof XMLHttpRequest !== 'undefined') {
                 try {
-                    xhr = new XDomainRequest();
+                    xhr = new XMLHttpRequest();
                 } catch (e) {
                     xhr = false;
                 }
-            } else if (window.XMLHttpRequest) {
+            } else if (typeof XDomainRequest !== 'undefined') {
                 try {
-                    xhr = new XMLHttpRequest();
+                    xhr = new XDomainRequest();
                 } catch (e) {
                     xhr = false;
                 }

--- a/src/multi-ajax.js
+++ b/src/multi-ajax.js
@@ -1,0 +1,77 @@
+define([
+    'aux/ajax'
+], function (Ajax) {
+
+    /**
+     * A module to perform several AJAX calls
+     * @exports multi-ajax
+     */
+
+    function MultiAjax () {
+        this._ajax = new Ajax();
+    }
+
+    /**
+     * Return a function that can be used as a callback for the Json loading requests.
+     *
+     * @memberOf module:multi-ajax
+     * @protected
+     *
+     * @param {string[]} urls Location of json files
+     * @param {integer} index Index of the url being processed
+     * @param {string} method Defaults to get
+     * @param {function} onload Success callback
+     * @param {function} onerror Error callback
+     * @param {Object[]} responses Partial response, array containing all the responses collected by previous requests
+     */
+    MultiAjax.prototype._loadJsonCallbackGenerator = function (urls, index, method, onload, onerror, responses) {
+        var $this = this;
+        return function (response) {
+            responses.push(response);
+            if (index < urls.length - 1) {
+                $this._loadJson.call($this, urls, index + 1, method, onload, onerror, responses);
+            } else {
+                onload(responses);
+            }
+        };
+    };
+
+    /**
+     * Request and parse a single Json object, using a generated callback to collect the response.
+     *
+     * @memberOf module:multi-ajax
+     * @protected
+     *
+     * @param {string[]} urls Location of json files
+     * @param {integer} index Index of the url being processed
+     * @param {string} method Defaults to get
+     * @param {function} onload Success callback
+     * @param {function} onerror Error callback
+     * @param {Object[]} responses Partial response, array containing all the responses collected by previous requests
+     */
+    MultiAjax.prototype._loadJson = function (urls, index, method, onload, onerror, responses) {
+        this._ajax.loadJson(
+            urls[index],
+            method,
+            this._loadJsonCallbackGenerator.call(this, urls, index, method, onload, onerror, responses),
+            onerror
+        );
+    };
+
+    /**
+     * Execute several ajax requests parsing the responses into a list of JSON objects.
+     *
+     * @memberOf module:multi-ajax
+     * @public
+     *
+     * @param {string[]} urls Location of json files
+     * @param {string} method Defaults to get
+     * @param {function} onload Success callback
+     * @param {function} onerror Error callback
+     */
+    MultiAjax.prototype.loadJson = function (urls, method, onload, onerror) {
+        this._loadJson.call(this, urls, 0, method, onload, onerror, []);
+    };
+
+    return MultiAjax;
+});

--- a/tests/multi-ajax.spec.js
+++ b/tests/multi-ajax.spec.js
@@ -1,0 +1,83 @@
+define([
+    'aux/multi-ajax',
+    'jasmine-ajax'
+], function (MultiAjax, jasmineAjax) {
+    describe('Multi-ajax utils', function () {
+
+        var multiAjax;
+
+        beforeEach(function () {
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest('a.json').andReturn({'responseText': '{}'});
+            jasmine.Ajax.stubRequest('b.json').andReturn({'responseText': '{}'});
+            jasmine.Ajax.stubRequest('c.json').andReturn({'responseText': '{}'});
+            jasmine.Ajax.stubRequest('error.json').andReturn({'responseText': 'Not a JSON'});
+            jasmine.Ajax.stubRequest('404.json').andReturn({'status': 404});
+
+            multiAjax = new MultiAjax();
+        });
+
+        afterEach(function () {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('should be able to initialise', function () {
+            expect(multiAjax.loadJson).toBeDefined();
+        });
+
+        it('should load json', function () {
+            spyOn(multiAjax._ajax, 'getRequest').and.callThrough();
+            var result = multiAjax.loadJson(['a.json']);
+
+            expect(result).not.toBeDefined();
+            expect(multiAjax._ajax.getRequest).toHaveBeenCalled();
+        });
+
+        it('should request every json', function () {
+            var success = false,
+                error = false;
+            spyOn(multiAjax, '_loadJsonCallbackGenerator').and.callThrough();
+            multiAjax.loadJson(['a.json', 'b.json', 'c.json'], 'get', function (response) {
+                expect(response).toEqual([{}, {}, {}]);
+                success = true;
+            }, function () {
+                error = true;
+            });
+
+            expect(success).toBe(true);
+            expect(error).toBe(false);
+            expect(multiAjax['_loadJsonCallbackGenerator'].calls.count()).toBe(3);
+        });
+
+        it('should stop on first error', function () {
+            var success = false,
+                error = false;
+            spyOn(multiAjax, '_loadJsonCallbackGenerator').and.callThrough();
+            multiAjax.loadJson(['a.json', 'error.json', 'c.json'], 'get', function () {
+                success = true;
+            }, function (response) {
+                expect(response.toString().substring(0, 13)).toEqual('SyntaxError: ');
+                error = true;
+            });
+
+            expect(success).toBe(false);
+            expect(error).toBe(true);
+            expect(multiAjax._loadJsonCallbackGenerator.calls.count()).toBe(2);
+        });
+
+        it('should stop on first 404', function () {
+            var success = false,
+                error = false;
+            spyOn(multiAjax, '_loadJsonCallbackGenerator').and.callThrough();
+            multiAjax.loadJson(['a.json', '404.json', 'c.json'], 'get', function () {
+                success = true;
+            }, function () {
+                error = true;
+            });
+
+            expect(success).toBe(false);
+            expect(error).toBe(true);
+            expect(multiAjax._loadJsonCallbackGenerator.calls.count()).toBe(2);
+        });
+    });
+});


### PR DESCRIPTION
Add a MultiAjax object that allows to request several urls by ajax easily.

Every new request is launched after receiving a response to the previous one.
Any error happening in the middle will trigger the error callback and will stop the processing.