### PR TITLE
Add isTrusted method to check events

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,6 +744,20 @@ isDefined(barney, 'function');
 
 
 
+# is-trusted
+  **Params**
+
+- event `Event` - The variable containing an event  
+
+**Returns**: `Boolean` - When the event is not trusted it will pass back false otherwise pass back true.  
+**Example**  
+```js
+isTrusted(MouseEvent);
+// Returns true/false
+```
+
+
+
 # load-script
   A loader for Javascript files on the page using a script tag.
 

--- a/docs/readme.hb
+++ b/docs/readme.hb
@@ -181,6 +181,12 @@ define([
   {{>exported~}}
 {{/module}}
 
+{{#module name="is-trusted"~}}
+  # {{>name}}
+  {{>body~}}
+  {{>exported~}}
+{{/module}}
+
 {{#module name="load-script"~}}
   # {{>name}}
   {{>body~}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/src/is-trusted.js
+++ b/src/is-trusted.js
@@ -1,0 +1,36 @@
+define([
+], function () {
+
+    /**
+     * @exports is-trusted
+     *
+     * Helper which checks whether an event is trusted or not.
+     * More about trusted events here: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
+     *
+     * If a browser doesn't support `isTrusted` we fallback to `clientX` and `clientY` properties. X and Y have to be
+     * greater than 0 to treat an event as trusted.
+     * More about `clientX`: http://www.w3schools.com/jsref/event_clientx.asp
+     *
+     * @param {Event} event     The variable containing an event
+     *
+     * @returns {Boolean} When the event is not trusted it will pass back false otherwise pass back true.
+     *
+     * @example
+     * ```js
+     * isTrusted(MouseEvent);
+     * // Returns true/false
+     * ```
+     */
+    function isTrusted (event) {
+        if ('isTrusted' in event) {
+            return event.isTrusted;
+        } else if (event.clientX > 0 && event.clientY > 0) {
+            return true;
+        }
+
+        // A browser doesn't support `isTrused` and `clientX` and `clientY` equal to 0. Event not trusted
+        return false;
+    }
+
+    return isTrusted;
+});

--- a/tests/is-trusted.spec.js
+++ b/tests/is-trusted.spec.js
@@ -2,7 +2,7 @@ define([
     'aux/is-trusted'
 ], function (isTrusted) {
 
-    fdescribe('Will check whether or not an event', function () {
+    describe('Will check whether or not an event', function () {
 
         describe('is trusted', function () {
             it('should return that an event is trusted when isTrusted defined', function () {

--- a/tests/is-trusted.spec.js
+++ b/tests/is-trusted.spec.js
@@ -1,0 +1,44 @@
+define([
+    'aux/is-trusted'
+], function (isTrusted) {
+
+    fdescribe('Will check whether or not an event', function () {
+
+        describe('is trusted', function () {
+            it('should return that an event is trusted when isTrusted defined', function () {
+                var event = {isTrusted: true};
+
+                expect(isTrusted(event)).toBeTruthy();
+            });
+
+            it('should return that an event is trusted when valid clientX/clientY defined', function () {
+                var event = {clientX: 10, clientY: 1};
+
+                expect(isTrusted(event)).toBeTruthy();
+            });
+        });
+
+        describe('is not trusted', function () {
+            it('should return false if isTrusted set to false', function () {
+                var event = {isTrusted: false};
+
+                expect(isTrusted(event)).toBeFalsy();
+            });
+
+            it('should return false if clientX and clientY set to 0', function () {
+                var event = {clientX: 0, clientY: 0};
+
+                expect(isTrusted(event)).toBeFalsy();
+            });
+
+            it('should return false if missing clientX or clientY', function () {
+                var eventNoX = {clientY: 10},
+                    eventNoY = {clientX: 10};
+
+                expect(isTrusted(eventNoX)).toBeFalsy();
+                expect(isTrusted(eventNoY)).toBeFalsy();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
JIRA: https://rockabox.atlassian.net/browse/RIG-1083

Helper which checks whether an event is trusted or not.
More about trusted events here: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted

If a browser doesn't support `isTrusted` we fallback to `clientX` and `clientY` properties. X and Y have to be greater than 0 to treat an event as trusted.
More about `clientX`: http://www.w3schools.com/jsref/event_clientx.asp