### PR TITLE
If screen larger than the parallax element do not use ratio 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/src/parallax-scrolling.js
+++ b/src/parallax-scrolling.js
@@ -69,7 +69,9 @@ define([
             eleHeight = params.eleHeight,
             offsetTop = params.offsetTop,
             visibleHeight = params.visibleHeight,
-            winPosition = params.winPosition;
+            winPosition = params.winPosition,
+            topPosition,
+            winHeight = winPosition.winHeight;
 
         if (this._isTop(winPosition, offsetTop, visibleHeight)) {
             scrollProgress = 0;
@@ -77,12 +79,44 @@ define([
         } else if (this._isScrollable(winPosition, offsetTop, visibleHeight)) {
             var ratio,
                 // How much the slot has scrolled compared to the window scroll position
-                scrollDistance = (offsetTop + visibleHeight) - winPosition.scrollTop;
+                scrollDistance = (offsetTop + visibleHeight) - winPosition.scrollTop,
+                bottom,
+                leftToShow;
 
             // Calculate how much the content has scrolled
-            scrollProgress = scrollDistance / winPosition.winHeight;
+            scrollProgress = scrollDistance / winHeight;
             ratio = eleHeight * scrollProgress;
             scrollY = visibleHeight - ratio;
+
+            // Is the Screen larger than the Parallax element
+            if (winHeight > eleHeight) {
+                // distance between starting point and the bottom of the window page.
+                bottom =  winHeight - scrollDistance;
+                // number of pixel left to show from the parallax element
+                leftToShow =  eleHeight - (visibleHeight + bottom);
+
+                if (leftToShow <= 0) {
+                    topPosition = offsetTop - winPosition.scrollTop;
+                    // If the element is at the top of the browser viewport
+                    if (topPosition <= 0) {
+                        scrollY = Math.abs(topPosition);
+                        // The scroll progress will be 100 percent when the top position is equal to the visibleHeight
+                        scrollProgress = 1 - ((eleHeight - (visibleHeight - scrollY)) / eleHeight);
+                    } else {
+                        // Parallax element is at the top of the creative element it stops scrolling until
+                        // the creative element reach the top of the window.
+                        scrollY = 0;
+                        // scrollProgress is equal to the parallax element height minus the size of element
+                        // that should be viewable at any time.
+                        scrollProgress = 1 - ((eleHeight - visibleHeight) / eleHeight);
+                    }
+                } else {
+                    // the scroll progress is calculate from initial size of the minimum viewable part base on
+                    // how many pixel it has scroll.
+                    scrollProgress = 1 - (bottom / eleHeight);
+                    scrollY = (visibleHeight + bottom) - eleHeight;
+                }
+            }
         } else {
             scrollProgress = 1;
             scrollY = visibleHeight - eleHeight;

--- a/tests/parallax-scrolling.spec.js
+++ b/tests/parallax-scrolling.spec.js
@@ -247,7 +247,11 @@ define([
 
                 scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
                     visibleHeight: 200,
-                    eleHeight: 100
+                    eleHeight: 100,
+                    winPosition: {
+                        scrollTop: 0,
+                        winHeight: 100
+                    }
                 });
 
                 expect(scrollPosition.scrollProgress).toBe(1);
@@ -259,7 +263,11 @@ define([
                 spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(true);
 
                 scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
-                    visibleHeight: 200
+                    visibleHeight: 200,
+                    winPosition: {
+                        scrollTop: 0,
+                        winHeight: 100
+                    }
                 });
 
                 expect(scrollPosition.scrollProgress).toBe(0);
@@ -284,6 +292,137 @@ define([
                 expect(scrollPosition.scrollProgress).toBe(0.2);
                 // The same as the visible height
                 expect(scrollPosition.scrollY).toBe(-40);
+            });
+
+            describe('when window height is larger than parallax element the `scrollProgress`', function () {
+                var scrollPercent,
+                    scrollTop,
+                    winHeight,
+                    visibleHeight,
+                    offsetTop,
+                    eleHeight;
+
+                it('should return 1 when top position is equal to the visibleHeight', function () {
+                    spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(false);
+                    spyOn(ParallaxScrolling.prototype, '_isScrollable').and.returnValue(true);
+                    scrollTop = 400;
+                    winHeight = 1000;
+                    visibleHeight = 200;
+                    offsetTop = 1200;
+                    eleHeight = 600;
+
+                    scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
+                        winPosition: {
+                            scrollTop: scrollTop,
+                            winHeight: winHeight
+                        },
+                        visibleHeight: visibleHeight,
+                        offsetTop: offsetTop,
+                        eleHeight: eleHeight
+                    });
+
+                    expect(scrollPosition.scrollProgress).toBe(1);
+                    expect(scrollPosition.scrollY).toBe(-400);
+                });
+
+                it('should return  0 if the element is at the top of the browser viewport', function () {
+                    spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(false);
+                    spyOn(ParallaxScrolling.prototype, '_isScrollable').and.returnValue(true);
+                    scrollTop = 1400;
+                    winHeight = 1000;
+                    visibleHeight = 200;
+                    offsetTop = 1200;
+                    eleHeight = 600;
+
+                    scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
+                        winPosition: {
+                            scrollTop: scrollTop,
+                            winHeight: winHeight
+                        },
+                        visibleHeight: visibleHeight,
+                        offsetTop: offsetTop,
+                        eleHeight: eleHeight
+                    });
+
+                    expect(scrollPosition.scrollProgress).toBe(0);
+                    expect(scrollPosition.scrollY).toBe(200);
+                });
+
+                it('should return `eleHeight` minus the number pixels the creative has pass the top', function () {
+                    spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(false);
+                    spyOn(ParallaxScrolling.prototype, '_isScrollable').and.returnValue(true);
+                    scrollTop = 1300;
+                    winHeight = 1000;
+                    visibleHeight = 200;
+                    offsetTop = 1200;
+                    eleHeight = 600;
+
+                    scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
+                        winPosition: {
+                            scrollTop: scrollTop,
+                            winHeight: winHeight
+                        },
+                        visibleHeight: visibleHeight,
+                        offsetTop: offsetTop,
+                        eleHeight: eleHeight
+                    });
+                    scrollPercent = 1 - ((eleHeight - 100) / eleHeight);
+
+                    expect(scrollPosition.scrollProgress).toBe(scrollPercent);
+                    expect(scrollPosition.scrollY).toBe(100);
+                });
+
+                it('should return number of pixel to the bottom divided by `eleHeight`', function () {
+                    spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(false);
+                    spyOn(ParallaxScrolling.prototype, '_isScrollable').and.returnValue(true);
+                    scrollTop = 650;
+                    winHeight = 1000;
+                    visibleHeight = 200;
+                    offsetTop = 1200;
+                    eleHeight = 600;
+
+                    scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
+                        winPosition: {
+                            scrollTop: scrollTop,
+                            winHeight: winHeight
+                        },
+                        visibleHeight: visibleHeight,
+                        offsetTop: offsetTop,
+                        eleHeight: eleHeight
+                    });
+                    topPosition = winHeight + scrollTop;
+                    creativeStartPosition = offsetTop + visibleHeight;
+                    scrollPercent = 1 - ((topPosition - creativeStartPosition) / eleHeight);
+
+                    expect(scrollPosition.scrollProgress).toBe(scrollPercent);
+                    expect(scrollPosition.scrollY).toBe(-150);
+                });
+
+                it('should return scrollY 0 if has show all parallax element but is not in the top yet', function () {
+                    spyOn(ParallaxScrolling.prototype, '_isTop').and.returnValue(false);
+                    spyOn(ParallaxScrolling.prototype, '_isScrollable').and.returnValue(true);
+                    scrollTop = 800;
+                    winHeight = 1000;
+                    visibleHeight = 200;
+                    offsetTop = 1200;
+                    eleHeight = 600;
+
+                    scrollPosition = ParallaxScrolling.prototype._getScrollPosition({
+                        winPosition: {
+                            scrollTop: scrollTop,
+                            winHeight: winHeight
+                        },
+                        visibleHeight: visibleHeight,
+                        offsetTop: offsetTop,
+                        eleHeight: eleHeight
+                    });
+                    topPosition = winHeight + scrollTop;
+                    creativeStartPosition = offsetTop + visibleHeight;
+                    scrollPercent = 1 - ((topPosition - creativeStartPosition) / eleHeight);
+
+                    expect(scrollPosition.scrollProgress).toBe(scrollPercent);
+                    expect(scrollPosition.scrollY).toBe(0);
+                });
             });
         });
 


### PR DESCRIPTION
If screen is larger than the parallax element use the number of pixels
that it has move up from the starting point and pause the scroll when
parallax element is on the top of the creative until the creative
reach the top of the view port and then start to push the parallax
element again.