### PR TITLE
Get URL Info smaller lib no CreateElement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/src/get-url-info.js
+++ b/src/get-url-info.js
@@ -1,6 +1,5 @@
 define([
-    'aux/create-element'
-], function (createElement) {
+], function () {
 
     /**
      * Gets information from about a url. Domain, Port, Protocol etc.
@@ -53,13 +52,10 @@ define([
             // Try to use the built in browser URL functions
             linkInfo = new window.URL(url);
         } catch (error) {
-            // When there is an error create an element in order to get the information (URL most likely not avaialbe
+            // When there is an error create an element in order to get the information (URL most likely not available
             // in current browser)
-            var ele = createElement('a', {
-                attr: {
-                    'href': url
-                }
-            });
+            var ele = document.createElement('a');
+            ele.setAttribute('href', url);
 
             linkInfo = {
                 'hash': ele.hash,


### PR DESCRIPTION
Stop using the `createElement` helper as part of `getUrlInfo` this will allow the use of this helper to be as small as possible.