### PR TITLE
v2.10.1 - Assign css styles as important.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "helpers"
   ],
   "author": [
-    "Rockabox <tech@rockabox.com> (http://rockabox.com)",
+    "Scoota <tech@scoota.com> (http://scoota.com)",
     "Nick White <nickswhite89@gmail.com> (http://nwhite89.github.io)"
   ],
   "license": "MIT",

--- a/src/attach-css.js
+++ b/src/attach-css.js
@@ -19,7 +19,7 @@ define([
      *    		'backgroundColor': 'black'
      *   	};
      *  attachCss(ele, css);
-     *  // Returns div (<div style="position: relative; background-colour: black"></div>)
+     *  // Returns div (<div style="position: relative; background-colour: black!important;"></div>)
      *  ```
      */
     function attachCss (ele, css) {
@@ -31,11 +31,21 @@ define([
 
         for (var rule in css) {
             if (css.hasOwnProperty(rule)) {
-                style[rule] = css[rule];
+                if (typeof style.setProperty === 'function') {
+                    style.setProperty(toSnakeCase(rule), css[rule], 'important');
+                } else {
+                    style[rule] = css[rule];
+                }
             }
         }
 
         return ele;
+    }
+
+    function toSnakeCase (rule) {
+        return rule.replace(/([A-Z])/g, function ($1) {
+            return '-' + $1.toLowerCase();
+        });
     }
 
     return attachCss;

--- a/tests/attach-css.spec.js
+++ b/tests/attach-css.spec.js
@@ -16,5 +16,11 @@ define([
 
             expect(ele.style.backgroundColor).toEqual(css.backgroundColor);
         });
+
+        it('should make the backgroundColour priority set as important', () => {
+            attachCss(ele, css);
+
+            expect(ele.style.getPropertyPriority('background-color')).toBe('important');
+        });
     });
 });


### PR DESCRIPTION
When assigning css styles to an element ensure that they are set as important.

**JIRA**
https://rockabox.atlassian.net/browse/RIG-3914

**Dependencies**
Auxilium.js: https://github.com/rockabox/Auxilium.js/pull/87
Formats: https://github.com/rockabox/rig_formats/pull/453