### PR TITLE
We should not set importance by default on css stylings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Auxilium.js",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {

--- a/src/attach-css.js
+++ b/src/attach-css.js
@@ -8,6 +8,7 @@ define([
      *
      * @param {object} ele    A DOM Element in which to add the CSS to.
      * @param {object} css CSS in which to add to the Element in an object
+     * @param {boolean} important Whether the css properties should be set as important
      *
      * @returns {object} ele  Passes the element with css attached to style attribute.
      *
@@ -22,7 +23,7 @@ define([
      *  // Returns div (<div style="position: relative; background-colour: black!important;"></div>)
      *  ```
      */
-    function attachCss (ele, css) {
+    function attachCss (ele, css, important) {
         if (!css) {
             return ele;
         }
@@ -31,7 +32,7 @@ define([
 
         for (var rule in css) {
             if (css.hasOwnProperty(rule)) {
-                if (typeof style.setProperty === 'function') {
+                if (typeof style.setProperty === 'function' && (important || rule === 'display')) {
                     style.setProperty(toSnakeCase(rule), css[rule], 'important');
                 } else {
                     style[rule] = css[rule];

--- a/tests/attach-css.spec.js
+++ b/tests/attach-css.spec.js
@@ -18,9 +18,23 @@ define([
         });
 
         it('should make the backgroundColour priority set as important', () => {
-            attachCss(ele, css);
+            attachCss(ele, css, true);
 
             expect(ele.style.getPropertyPriority('background-color')).toBe('important');
+        });
+
+        it('should alaways set the display property as important', () => {
+            attachCss(ele, {
+                'display': 'block'
+            });
+
+            expect(ele.style.getPropertyPriority('display')).toBe('important');
+        });
+
+        it('should NOT make the backgroundColour priority set as important as passed false', () => {
+            attachCss(ele, css, false);
+
+            expect(ele.style.getPropertyPriority('background-color')).toBe('');
         });
     });
 });


### PR DESCRIPTION
Allow specifying the importance for CSS _but_ if the property is `display` always set it as `important`.

**JIRA**
https://rockabox.atlassian.net/browse/RIG-3924

**Dependencies**
PR Formats: https://github.com/rockabox/rig_formats/pull/456
PR Aux: https://github.com/rockabox/Auxilium.js/pull/88