### PR TITLE
Move Auxilium to use GitHub packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ node_js:
   - "6.10"
 addons:
   firefox: "55.0"
-before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 script:
-  - npm run test-ci
+  - npm run test

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "lodash-node": "~3.1.0",
     "webpack": "~1.15.0",
     "webpack-dev-middleware": "~1.12.2"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "Auxilium.js",
-  "version": "2.10.2",
+  "name": "@rockabox/auxilium",
+  "version": "3.0.0",
   "description": "A webpacked utility library.",
   "main": "src/index.js",
   "scripts": {
@@ -20,10 +20,7 @@
     "utils",
     "helpers"
   ],
-  "author": [
-    "Scoota <tech@scoota.com> (http://scoota.com)",
-    "Nick White <nickswhite89@gmail.com> (http://nwhite89.github.io)"
-  ],
+  "author": "Scoota <tech@scoota.com> (http://scoota.com)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rockabox/Auxilium.js/issues"


### PR DESCRIPTION
Move Auxilium to use GitHub packages.

- Author should only be a string
- Name must be prefixed with `@rockabox`
- Name must be lowercase
- Add GitHub npm packages registry
- Update version to v3 as complete move of package.

**JIRA**
https://rockabox.atlassian.net/browse/RIG-4210

**Dependencies**
Auxilium.js: https://github.com/rockabox/Auxilium.js/pull/89
Hotspots: https://github.com/rockabox/hotspots/pull/2